### PR TITLE
Add 'Free' to title and tags

### DIFF
--- a/automatic/iobit-malware-fighter/iobit-malware-fighter.nuspec
+++ b/automatic/iobit-malware-fighter/iobit-malware-fighter.nuspec
@@ -33,14 +33,14 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <!-- This section is about the software itself -->
-    <title>IObit Malware Fighter</title>
+    <title>IObit Malware Fighter Free</title>
     <authors>IObit</authors>
     <!-- projectUrl is required for the community feed -->
     <projectUrl>https://www.iobit.com/en/malware-fighter.php</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/mkevenaar/chocolatey-packages@4ff8fee8fd1be773bca0fc0b629ce53643c5efb7/icons/iobit-malware-fighter.png</iconUrl>
     <!-- copyright is usually years and software vendor, but not required for internal feeds -->
     <copyright>IObit. All rights reserved.</copyright>
-    <tags>iobit-malware-fighter admin</tags>
+    <tags>iobit-malware-fighter admin free</tags>
     <releaseNotes>http://forums.iobit.com/forum/general-forums/news-offers</releaseNotes>
     <licenseUrl>http://www.iobit.com/en/eula.php</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
The word "free" is mentioned only in the "summary", but in the gallery or the description page, you see title, keywords, and description only. This will make the package less ambiguous, so users can be sure they are not installing the pro version.