### PR TITLE
(winrar) Support language: Chinese Traditional

### DIFF
--- a/automatic/winrar/tools/downloadInfo.csv
+++ b/automatic/winrar/tools/downloadInfo.csv
@@ -16,3 +16,4 @@ ru|https://www.rarlab.com/rar/winrar-x64-570ru.exe|a0c029bd3c177089f1047f8d4203a
 slv|https://www.rarlab.com/rar/winrar-x64-570slv.exe|303b9e42de4b14d53c166b235e4dcacc1ab507bba22b2339068a5e9850ff5c70|https://www.rarlab.com/rar/wrar570slv.exe|36146d0d29f155352e377bff700a12bc9d6ed25132d57b5d0df556f8975d25d6
 sw|https://www.rarlab.com/rar/winrar-x64-570sw.exe|e58ffd99a2366074dea6a039a7d2c1e3f0b3ea343e8708b0a618f8437f015ba2|https://www.rarlab.com/rar/wrar570sw.exe|afedadebbdda8a0849402e3c558e24608be7fcedf001d75fcbd7a4675bfe10c4
 uk|https://www.rarlab.com/rar/winrar-x64-570uk.exe|7373f897c7319a5aab8c07d201c5466015b794835d0f6c6f65a50293fdaefdaf|https://www.rarlab.com/rar/wrar570uk.exe|b3b15cb68a07168e36a19fc0fb38339bea1542ff15dfdbf32cd21bab5b095833
+tc|https://www.rarlab.com/rar/winrar-x64-570tc.exe|7fd408105daa8f6277ef62f065f531482c04e1f3782872620b120a3f0652d4c1|https://www.rarlab.com/rar/wrar570tc.exe|6a14717043d54e36939e5696e76d62cc39e3298f724119d2279b237747658d18


### PR DESCRIPTION
To fixed that download info of language "Chinese Traditional" was missing before.