### PR TITLE
nginx: Get-NginxPaths pick up the latest nginx path.

### DIFF
--- a/automatic/nginx/tools/helpers.ps1
+++ b/automatic/nginx/tools/helpers.ps1
@@ -37,7 +37,7 @@ function Get-NginxPaths {
         [Parameter(Position = 0, Mandatory)][ValidateNotNullOrEmpty()][string] $installDir
     )
 
-    $nginxDir = Get-ChildItem $installDir -Directory -Filter 'nginx*' | Select-Object -First 1 -ExpandProperty FullName
+    $nginxDir = Get-ChildItem $installDir -Directory -Filter 'nginx*' | Sort-Object { -join $_.Name.Replace('-','.').Split('.').PadLeft(3) } -Descending | Select-Object -First 1 -ExpandProperty FullName
     $confPath = Join-Path $nginxDir 'conf\nginx.conf'
     $binPath = Join-Path $nginxDir 'nginx.exe'
 


### PR DESCRIPTION
## Suggestion for upgrading nginx package

I suggest a patch for Get-NginxPaths in helpers.ps1, because it didn't work that choco upgrade nginx 1.15.8 to 1.15.9.

I had already installed nginx 1.15.8 by `choco install nginx` before upgrading to nginx 1.15.9. When I run `choco upgrade nginx`, It succeeded and nginx 1.15.9 had been installed to the another folder `nginx-1.15.9`. But the result of `nssm dump nginx` told nginx 1.15.8 not 1.15.9. Also the content of `ProgramData\chocolatey\lib\nginx\config.xml` told 1.15.8, too.

I think that the function `Get-NginxPaths` in helpers.ps1 should sort by version numbers, and pick up the latest version from some versions in same install-location.

## As an Example

The following is example of sorting some versions in install-location.

* Bad order (without sorting)
    ```
    nginx-1.15.1
    nginx-1.15.10
    nginx-1.15.8
    nginx-1.15.9
    ```

* Expected order
    ```
    nginx-1.15.10
    nginx-1.15.9
    nginx-1.15.8
    nginx-1.15.1
    ```

## No test overall

I have not yet tested overall that choco upgrade nginx. I have inspected only changed line. I hope you'll test that choco upgrade nginx.

```
Get-ChildItem $installDir -Directory -Filter 'nginx*' | Sort-Object { -join $_.Name.Replace('-','.').Split('.').PadLeft(3) } -Descending | Select-Object -First 1 -ExpandProperty FullName
```

Thanks.