### PR TITLE
Make MySQL install script more configurable

### DIFF
--- a/automatic/mysql/README.md
+++ b/automatic/mysql/README.md
@@ -5,3 +5,12 @@ MySQL Community Edition is the freely downloadable version of the world's most p
 **Please Note**: This is an automatically updated package. If you find it is
 out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.
+
+### Package Parameters
+The package accepts the following optional parameters:
+* `/installLocation` - filesystem location for mysql binaries
+* `/dataLocation` - filesystem location for mysql data
+* `/port` - numberic TCP listening port
+* `/serviceName` - custom name for the Windows services entry
+
+Example: `choco install mysql --params "/port:3307 /serviceName:AltSQL"`

--- a/automatic/mysql/tools/chocolateyInstall.ps1
+++ b/automatic/mysql/tools/chocolateyInstall.ps1
@@ -35,8 +35,8 @@ $installedContentsDir = get-childitem $installDir -include 'mysql*' | Sort-Objec
 # shut down service if running
 try {
   write-host "Shutting down MySQL if it is running"
-  Start-ChocolateyProcessAsAdmin "cmd /c NET STOP $(serviceName)"
-  Start-ChocolateyProcessAsAdmin "cmd /c sc delete $(serviceName)"
+  Start-ChocolateyProcessAsAdmin "cmd /c NET STOP $serviceName"
+  Start-ChocolateyProcessAsAdmin "cmd /c sc delete $serviceName"
 } catch {
   # no service installed
 }
@@ -61,7 +61,7 @@ if (!(Test-Path($iniFileDest))) {
 [mysqld]
 basedir=$($installDir.Replace("\","\\"))\\current
 datadir=$($dataDir.Replace("\","\\"))\\data
-port=$(port)
+port=$port
 "@ | Out-File $iniFileDest -Force -Encoding ASCII
 }
 
@@ -79,7 +79,7 @@ try {
 
 # install the service itself
 write-host "Installing the mysql service"
-Start-ChocolateyProcessAsAdmin "cmd /c '$($installDirBin)\mysqld' --install $(serviceName)"
+Start-ChocolateyProcessAsAdmin "cmd /c '$($installDirBin)\mysqld' --install $serviceName"
 # turn on the service
-Start-ChocolateyProcessAsAdmin "cmd /c NET START $(serviceName)"
+Start-ChocolateyProcessAsAdmin "cmd /c NET START $serviceName"
 


### PR DESCRIPTION
Could this package be extended with some optional install parameters? I'd like to be able to install multiple instances of MySQL side-by-side on the same host - primarily for convenience testing deployment scripts for different WAMP apps.

Adds parameters:
```
/installLocation => path for MySQL binaries
/dataLocation => path for MySQL data
/port => TCP listen port
/serviceName => alternate service name
```