### PR TITLE
(nginx) Add /ServiceAccount package parameter

### DIFF
--- a/automatic/nginx/README.md
+++ b/automatic/nginx/README.md
@@ -8,6 +8,7 @@ nginx [engine x] is an HTTP and reverse proxy server, a mail proxy server, a gen
 * `/serviceName` - The name of the windows service which will be create. Default: `nginx`
 * `/port` - The port Nginx will listen to. Default: `80`
 * `/noService` - Don't install the nginx windows service
+* `/serviceAccount` - account to run Windows Service. One of `System`, `LocalService` or `NetworkService`. Default: `System`
 
 Example: `choco install nginx --params '"/installLocation:C:\nginx /port:433"'`
 

--- a/automatic/nginx/legal/VERIFICATION.txt
+++ b/automatic/nginx/legal/VERIFICATION.txt
@@ -6,12 +6,12 @@ The installer have been downloaded from their official download link listed on <
 and can be verified like this:
 
 1. Download the following installers:
-  32-Bit: <https://nginx.org/download/nginx-1.17.8.zip>
+  32-Bit: <https://nginx.org/download/nginx-1.17.9.zip>
 2. You can use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'
 
   checksum type: sha256
-  checksum32: DE82E682A147DA48E0CD8C4C2A905D69DDB8836CDBBE04D630E69C7A410FDFE1
+  checksum32: 4CF6F20CACBF72C4B47A89F9EA9823B012B3F4B4C84427169EE5F3DD9000BFB0
 
 File 'LICENSE.txt' is obtained from <https://nginx.org/LICENSE>

--- a/automatic/nginx/nginx.nuspec
+++ b/automatic/nginx/nginx.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>1.17.8</version>
+    <version>1.17.9</version>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Maurice Kevenaar</owners>
     <!-- ============================== -->
@@ -58,6 +58,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 * `/serviceName` - The name of the windows service which will be create. Default: `nginx`
 * `/port` - The port Nginx will listen to. Default: `80`
 * `/noService` - Don't install the nginx windows service
+* `/serviceAccount` - account to run Windows Service. One of `System`, `LocalService` or `NetworkService`. Default: `System`
 
 Example: `choco install nginx --params '"/installLocation:C:\nginx /port:433"'`
 

--- a/automatic/nginx/tools/chocolateyInstall.ps1
+++ b/automatic/nginx/tools/chocolateyInstall.ps1
@@ -5,10 +5,11 @@ $pp = Get-PackageParameters
 
 $arguments = @{
     packageName = $env:chocolateyPackageName
-    file        = "$toolsDir\nginx-1.17.8.zip"
+    file        = "$toolsDir\nginx-1.17.9.zip"
     destination = if ($pp.installLocation) { $pp.installLocation } else { Get-ToolsLocation }
     port        = if ($pp.Port) { $pp.Port } else { 80 }
     serviceName = if ($pp.NoService) { $null } elseif ($pp.serviceName) { $pp.serviceName } else { 'nginx' }
+    serviceAccount = if ($pp.ServiceAccount) { $pp.ServiceAccount } else { 'SYSTEM' }
 }
 
 if (-not (Assert-TcpPortIsOpen $arguments.port)) {

--- a/automatic/nginx/tools/helpers.ps1
+++ b/automatic/nginx/tools/helpers.ps1
@@ -86,6 +86,7 @@ function Install-NginxService {
     nssm set $($arguments.serviceName) AppDirectory  "$($nginxPaths.NginxDir)" 2>&1 | Out-Null
     nssm set $($arguments.serviceName) AppNoConsole 1 2>&1 | Out-Null # Mentioned on top off http://nssm.cc/download
     nssm set $($arguments.serviceName) AppStopMethodSkip 7 2>&1 | Out-Null
+    nssm set $($arguments.serviceName) ObjectName "$($arguments.ServiceAccount)" 2>&1 | Out-Null
     nssm start $($arguments.serviceName) 2>&1 | Out-Null
 }
 
@@ -116,6 +117,7 @@ function Set-NginxInstallOptions {
         Destination = $nginxPaths.NginxDir
         BinPath   = $nginxPaths.BinPath
         ServiceName = $arguments.serviceName
+        ServiceAccount = $arguments.ServiceAccount
     }
 
     $configFile = Join-Path $env:chocolateyPackageFolder 'config.xml'


### PR DESCRIPTION
## Description

- Also includes 1.17.9 (missing from repo, but already published)

Implements #48

## Motivation and Context
Allow nginx to run under lower-privilege service accounts

## How Has this Been Tested?
Tested locally

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
