### PR TITLE
(microsoft-windows-terminal) AU won't update to pre-release versions

### DIFF
--- a/automatic/microsoft-windows-terminal/update.ps1
+++ b/automatic/microsoft-windows-terminal/update.ps1
@@ -10,13 +10,23 @@ function global:au_GetLatest {
   }
   $download_page = Invoke-RestMethod -Uri $releases -Headers $header
   forEach ($release in $download_page) {
-    if (!$release.prerelease) {
+    if ($release.prerelease) {
+      $version = $release.tag_name.Replace('v', '')
+      $version += '-beta'
       forEach ($asset in $release.assets) {
         if ($asset.name -like "Microsoft.WindowsTerminal_*") {
           $url = $asset.browser_download_url
         }
       }
-      $version = $release.tag_name.Remove(0, 1)
+      break
+    }
+    else {
+      $version = $release.tag_name.Replace('v', '')
+      forEach ($asset in $release.assets) {
+        if ($asset.name -like "Microsoft.WindowsTerminal_*") {
+          $url = $asset.browser_download_url
+        }
+      }
       break
     }
   }

--- a/automatic/microsoft-windows-terminal/update.ps1
+++ b/automatic/microsoft-windows-terminal/update.ps1
@@ -5,20 +5,24 @@ $releases = 'https://api.github.com/repos/microsoft/terminal/releases' # should 
 function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
 
 function global:au_GetLatest {
-    $download_page = Invoke-RestMethod -Uri $releases # should variable name change?: releases instead of download_page
-    forEach ($release in $download_page){
-        if (!$release.prerelease) {
-            $version = $release.tag_name.Remove(0,1) # Removes the character v from the tag_name
-            $url = $release.assets.browser_download_url
-            break
+  $download_page = Invoke-RestMethod -Uri $releases # should variable name change?: releases instead of download_page
+  forEach ($release in $download_page) {
+    if (!$release.prerelease) {
+      forEach ($asset in $release.assets) {
+        if ($asset.name -like "Microsoft.WindowsTerminal_*") {
+          $url = $asset.browser_download_url
         }
+      }
+      $version = $release.tag_name.Remove(0, 1) # Removes the character v from the tag_name
+      break
     }
-    return @{
-        URL32 = $url
-        Version = $version
-        RemoteVersion  = $version
-        FileType = 'msixbundle'
-    }
+  }
+  return @{
+      URL32 = $url
+      Version = $version
+      RemoteVersion  = $version
+      FileType = 'msixbundle'
+  }
 }
 
 function global:au_SearchReplace {

--- a/automatic/microsoft-windows-terminal/update.ps1
+++ b/automatic/microsoft-windows-terminal/update.ps1
@@ -1,19 +1,18 @@
 Import-Module au
 
-$releases = 'https://github.com/microsoft/terminal/releases'
+$releases = 'https://api.github.com/repos/microsoft/terminal/releases' # should variable name change?: releases_page instead of releases
 
 function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
-
-    #Microsoft.WindowsTerminal_0.2.1831.0_8wekyb3d8bbwe.msixbundle
-    $re  = "Microsoft.WindowsTerminal_(.+)_.*.msixbundle"
-    $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href
-
-    $version = ([regex]::Match($url,$re)).Captures.Groups[1].value
-    $url = 'https://github.com' + $url
-
+    $download_page = Invoke-RestMethod -Uri $releases # should variable name change?: releases instead of download_page
+    forEach ($release in $download_page){
+        if (!$release.prerelease) {
+            $version = $release.tag_name.Remove(0,1) # Removes the character v from the tag_name
+            $url = $release.assets.browser_download_url
+            break
+        }
+    }
     return @{
         URL32 = $url
         Version = $version

--- a/automatic/microsoft-windows-terminal/update.ps1
+++ b/automatic/microsoft-windows-terminal/update.ps1
@@ -1,11 +1,14 @@
 Import-Module au
 
-$releases = 'https://api.github.com/repos/microsoft/terminal/releases' # should variable name change?: releases_page instead of releases
+$releases = 'https://api.github.com/repos/microsoft/terminal/releases'
 
 function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
 
 function global:au_GetLatest {
-  $download_page = Invoke-RestMethod -Uri $releases # should variable name change?: releases instead of download_page
+  $header = @{
+    "Authorization" = "token $env:github_api_key"
+  }
+  $download_page = Invoke-RestMethod -Uri $releases -Headers $header
   forEach ($release in $download_page) {
     if (!$release.prerelease) {
       forEach ($asset in $release.assets) {
@@ -13,15 +16,15 @@ function global:au_GetLatest {
           $url = $asset.browser_download_url
         }
       }
-      $version = $release.tag_name.Remove(0, 1) # Removes the character v from the tag_name
+      $version = $release.tag_name.Remove(0, 1)
       break
     }
   }
   return @{
-      URL32 = $url
-      Version = $version
-      RemoteVersion  = $version
-      FileType = 'msixbundle'
+    URL32 = $url
+    Version = $version
+    RemoteVersion  = $version
+    FileType = 'msixbundle'
   }
 }
 

--- a/automatic/microsoft-windows-terminal/update.ps1
+++ b/automatic/microsoft-windows-terminal/update.ps1
@@ -10,25 +10,16 @@ function global:au_GetLatest {
   }
   $download_page = Invoke-RestMethod -Uri $releases -Headers $header
   forEach ($release in $download_page) {
+    $version = $release.tag_name.Replace('v', '')
     if ($release.prerelease) {
-      $version = $release.tag_name.Replace('v', '')
       $version += '-beta'
-      forEach ($asset in $release.assets) {
-        if ($asset.name -like "Microsoft.WindowsTerminal_*") {
-          $url = $asset.browser_download_url
-        }
-      }
-      break
     }
-    else {
-      $version = $release.tag_name.Replace('v', '')
-      forEach ($asset in $release.assets) {
-        if ($asset.name -like "Microsoft.WindowsTerminal_*") {
-          $url = $asset.browser_download_url
-        }
+    forEach ($asset in $release.assets) {
+      if ($asset.name -like "Microsoft.WindowsTerminal_*") {
+        $url = $asset.browser_download_url
       }
-      break
     }
+    break
   }
   return @{
     URL32 = $url


### PR DESCRIPTION
Windows Terminal is scheduled to get a new release around July 20. At that time, AU won't update the chocolatey package if the new release is a pre-release. If the release is a normal stable release, AU should update the chocolatey package.

## Description
- Use Invoke-RestMethod to parse the JSON output into a PSObject.
- Check if the release is not a pre-release and then get `$url`.
- Break loop as soon as the first stable release is found.

## Motivation and Context
Partially fixes mkevenaar/chocolatey-packages#55

## How Has this Been Tested?
- Used `Write-Host` to print variables and make sure that the output is exactly what is expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
