### PR TITLE
(crystaldiskinfo) (Both .install and .portable) Remove binaries from tools directory

### DIFF
--- a/automatic/crystaldiskinfo.install/tools/chocolateyInstall.ps1
+++ b/automatic/crystaldiskinfo.install/tools/chocolateyInstall.ps1
@@ -13,3 +13,4 @@ $packageArgs = @{
 
 Install-ChocolateyInstallPackage @packageArgs
 
+Get-ChildItem $toolsDir\*.exe | ForEach-Object { Remove-Item $_ -ea 0; if (Test-Path $_) { Set-Content "$_.ignore" } }

--- a/automatic/crystaldiskinfo.portable/tools/chocolateyInstall.ps1
+++ b/automatic/crystaldiskinfo.portable/tools/chocolateyInstall.ps1
@@ -14,6 +14,8 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage  @packageArgs
 
+Remove-Item -ea 0 -Path $toolsDir\*.zip
+
 #install start menu shortcut
 $fileName = $fileName32
 $is64bit = Get-OSArchitectureWidth 64

--- a/automatic/crystaldiskinfo.portable/tools/chocolateyInstall.ps1
+++ b/automatic/crystaldiskinfo.portable/tools/chocolateyInstall.ps1
@@ -8,11 +8,11 @@ $linkName = "CrystalDiskInfo.lnk"
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
-  unzipLocation  = $toolsDir
+  destination    = $toolsDir
   file          = "$toolsDir\CrystalDiskInfo8_9_0.zip"
 }
 
-Install-ChocolateyZipPackage  @packageArgs
+Get-ChocolateyUnzip  @packageArgs
 
 Remove-Item -ea 0 -Path $toolsDir\*.zip
 


### PR DESCRIPTION
## Description

1. Removes `.exe`(s) from the `crystaldiskinfo.install` tools directory
2. Removes `.zip`(s) from the `crystaldiskinfo.portable` tools directory
3. Switches `crystaldiskinfo.portable` from `Install-ChocolateyZipPackage` to `Get-ChocolateyUnzip`. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

More efficient disk usage, as there is no longer an extra copy of the program hanging arround.
(Slightly) Quicker installs for `crystaldiskinfo.portable` as it no longer copies the zip to temp.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

Tested in the new 2.0 test env (yay, I'm so happy it's been updated), and on a win 10 machine.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
