### PR TITLE
(dymo-label) Updated to latest version

### DIFF
--- a/automatic/dymo-label/_update.ps1
+++ b/automatic/dymo-label/_update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'http://www.dymo.com/en-US/online-support'
+$releases = 'https://www.dymo.com/on/demandware.store/Sites-dymo-Site/en_US/Support-user-guides'
 
 function global:au_SearchReplace {
     @{
@@ -13,12 +13,14 @@ function global:au_SearchReplace {
 }
 
 function global:au_GetLatest {
-    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+    Invoke-WebRequest -uri http://www.dymo.com -SessionVariable dl -method post
+
+    $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing -WebSession $dl
 
     $re = "DL.+Setup.+.exe"
     $url = $download_page.links | ? href -match $re | select -First 1 -expand href
 
-    $version = ([regex]::Match($url,'DL.+Setup.(.+).exe')).Captures.Groups[1].value
+    $version = ([regex]::Match($url,'DL.+Setup(.+).exe')).Captures.Groups[1].value
 
     return @{ 
         URL32 = $url

--- a/automatic/dymo-label/dymo-label.nuspec
+++ b/automatic/dymo-label/dymo-label.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>8.7.3</version>
+    <version>8.7.4</version>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Maurice Kevenaar</owners>
     <!-- ============================== -->
@@ -52,7 +52,6 @@ Enables you to create and print labels - all without the hassles of printing she
 **Please Note**: This is an automatically updated package. If you find it is
 out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.
-
 ]]></description>
     <!-- =============================== -->  
 

--- a/automatic/dymo-label/tools/chocolateyInstall.ps1
+++ b/automatic/dymo-label/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url          = 'http://download.dymo.com/dymo/Software/Win/DLS8Setup.8.7.3.exe'
-$checksum     = 'd7b55a5e1431d5b44241bee91d1841a5cd1990480dfcb73c9f80f57dc6b9c803'
+$url          = 'https://s3.amazonaws.com/download.dymo.com/dymo/Software/Win/DLS8Setup8.7.4.exe'
+$checksum     = '409d79f053ba0c803ce83b71e8245992cd63708fa27017f48a5063826f1bea4d'
 $checksumType = 'sha256'
 
 $packageArgs = @{


### PR DESCRIPTION
(dymo-label) Updated to latest version


## Description
- Updated dymo-label to v8.7.4.
- Updated the AU URL to reflect possible recent changes to Dymo's download page(s). Also adjusted the regex matching and Invoke-WebRequest to find the latest version

## Motivation and Context
Dymo recently updated their label software to 8.7.4. The previous URL in the AU script did not appear to link to any programs.

## How Has this Been Tested?
- Ran the auto updater on the dymo-label package
- Installed the updated nuspec package on a test system running Windows 10 Pro 20h2 that did not previously have Dymo Label installed. Dymo Label 8.7.4 appeared to install successfully and opened OK.
- Ran ` choco uninstall dymo-label` and confirmed Dymo Label was removed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
