### PR TITLE
5.0.2.22 Veeam Support

### DIFF
--- a/automatic/veeam-backup-for-microsoft-office-365/tools/chocolateyinstall.ps1
+++ b/automatic/veeam-backup-for-microsoft-office-365/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$url = 'https://download2.veeam.com/VeeamKB/4158/VeeamBackupOffice365_5.0.1.252_KB4158.zip'
+$url = 'https://download2.veeam.com/VBO/v5/VeeamBackupOffice365_5.0.2.22.zip'
 $checksum = 'd3eba9b999d39c9118881ff3d74b582b1be0e9ffb24c43f152905bb15e036b2f'
 $checksumType = 'sha256'
 $version = '5.0.1.252'

--- a/automatic/veeam-backup-for-microsoft-office-365/tools/chocolateyinstall.ps1
+++ b/automatic/veeam-backup-for-microsoft-office-365/tools/chocolateyinstall.ps1
@@ -2,9 +2,9 @@
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $url = 'https://download2.veeam.com/VBO/v5/VeeamBackupOffice365_5.0.2.22.zip'
-$checksum = 'd3eba9b999d39c9118881ff3d74b582b1be0e9ffb24c43f152905bb15e036b2f'
+$checksum = '64b5da0e271013b06f133b8e28cb267ce019185641939da4a0b3c866c48420c1'
 $checksumType = 'sha256'
-$version = '5.0.1.252'
+$version = '5.0.2.22'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName


### PR DESCRIPTION
Added new Veeam link to support latest version. Also fixed the fact that this is a KB Update, not a clean install.

## Description
Added latest version link for Veeam 5.0.2.22

## Motivation and Context
Does not do a clean install. It fails when downloading the package because .msi is not there (because it being a KB update)



## How Has this Been Tested?
choco install veeam-backup-for-microsoft-office-365 gives error:
Package parameters incorrect, either File or File64 must be specified.

## Types of changes
Bug fix and updated to latest version
