### PR TITLE
PowerToys: silentArgs with one minus sign

### DIFF
--- a/automatic/powertoys/tools/chocolateyinstall.ps1
+++ b/automatic/powertoys/tools/chocolateyinstall.ps1
@@ -19,7 +19,7 @@ $packageArgs = @{
   softwareName  = 'PowerToys*'
   file          = $fileName
   fileType      = 'exe'
-  silentArgs    = "--silent"
+  silentArgs    = "-silent"
   validExitCodes= @(0,1641,3010)
 }
 


### PR DESCRIPTION
## Description
it has to be just one minus sign according to the docs. I have also tested it. The install is only silent with one minus sign.
https://docs.microsoft.com/en-us/windows/powertoys/install#installer-args

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/mkevenaar/chocolatey-packages/issues/121

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)