### PR TITLE
(icloud) Add 3010 to valid exit codes

### DIFF
--- a/automatic/icloud/icloud.nuspec
+++ b/automatic/icloud/icloud.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>7.21.0.23</version>
+    <version>7.21.0.2300</version>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Maurice Kevenaar</owners>
     <!-- ============================== -->

--- a/automatic/icloud/icloud.nuspec
+++ b/automatic/icloud/icloud.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>7.21.0.2300</version>
+    <version>7.21.0.23</version>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Maurice Kevenaar</owners>
     <!-- ============================== -->

--- a/automatic/icloud/tools/chocolateyinstall.ps1
+++ b/automatic/icloud/tools/chocolateyinstall.ps1
@@ -10,7 +10,7 @@ $packageArgs = @{
   checksum       = '4CFD20D13CDCE2B5C435F2DDAF4EE4C81D976461846BF3B954E8AF6CBCDEB9F7'
   checksumType   = 'sha256'
   silentArgs     = "/qn /norestart"
-  validExitCodes = @(0, 2010, 1603, 1641)
+  validExitCodes = @(0, 2010, 1603, 1641, 3010)
   unzipLocation  = Get-PackageCacheLocation
 }
 


### PR DESCRIPTION
## Description
Fairly straightforward change: adds exit code 3010 (`ERROR_SUCCESS_REBOOT_REQUIRED`) to the install script's list of valid exit codes.

## Motivation and Context
I was working on updating a package that has a runtime dependency on a DLL distributed with the non-Microsoft Store version of iCloud (i.e the same installer consumed by the `icloud` package). In my environment, `iCloud64.msi` returned this while testing an upgrade to the latest version available.

Interestingly, while this does not fail the package install itself, the exclusion does cause `Start-ChocolateyProcessAsAdmin` to write a misleading error.

Example log file:
[choco iCloud.log](https://github.com/mkevenaar/chocolatey-packages/files/8934646/choco.iCloud.log)

## How Has this Been Tested?
### Environments
#### Dev
* OS Build: Windows 11 Pro v10.0.22000.0 (64-bit)
* PowerShell version: 7.2.4
* Chocolatey version: 1.1.0

#### Test
* OS Build: WIndows 10 Pro v10.0.17763.0 (32-bit)
* PowerShell version: 5.1.17763.1490
* Chocolatey version: 1.1.0

**NOTE**: This package is incompatible with the official Chocolatey Testing Environment, since `iCloud64.msi` prevents installation on a server OS.

### Steps
1. Confirm iCloud is NOT currently installed. If currently installed, uninstall it first.
2. Bump Nuspec's version using package fix notation (included in this changeset).
3. Create test package version using `choco pack`.
4. Install an older version of iCloud (e.g. `choco install icloud --version=7.18.0.22`).
5. Reboot to ensure iCloud installation is in a known-good state.
6. Upgrade to test package version (e.g. `choco upgrade icloud --source=.`).
7. Inspect installation output and confirm the following:
    * Package installation succeeds
    * Returned exit code is 3010
    * No errors are written relating to exit code

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
