### PR TITLE
(crystaldiskinfo.portable) Close all packaged processes before upgrade/uninstall

### DIFF
--- a/automatic/crystaldiskinfo.portable/tools/chocolateyBeforeModify.ps1
+++ b/automatic/crystaldiskinfo.portable/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,4 @@
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+. $toolsDir\helpers.ps1
+
+Stop-CrystalDiskInfo

--- a/automatic/crystaldiskinfo.portable/tools/chocolateyInstall.ps1
+++ b/automatic/crystaldiskinfo.portable/tools/chocolateyInstall.ps1
@@ -1,6 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+. $toolsDir\helpers.ps1
+
+Stop-CrystalDiskInfo
 
 $fileName32 = "DiskInfo32.exe"
 $fileName64 = "DiskInfo64.exe"

--- a/automatic/crystaldiskinfo.portable/tools/helpers.ps1
+++ b/automatic/crystaldiskinfo.portable/tools/helpers.ps1
@@ -1,0 +1,8 @@
+function Stop-CrystalDiskInfo() {
+    $processNameFilters = @("opusdec", "AlertMail*", "DiskInfo*")
+
+    foreach ($processName in $processNameFilters)
+    {
+        Get-Process -Name $processName -ErrorAction SilentlyContinue | Stop-Process -Force
+    }
+}


### PR DESCRIPTION
## Description
This changeset ensures that all currently known executables associated with `crystaldiskinfo.portable` (i.e. `DiskInfo32.exe/DiskInfo64.exe`, `AlertMail.exe`/`AlertMail4.exe`/`AlertMail48.exe`, and `opusdec.exe`) are stopped before attempting an upgrade or uninstall.

## Motivation and Context
I have CrystalDiskInfo configured to run in Resident mode. When I close the window, the process will persist in Windows's system tray and continues to run as a background process. This comes in handy when monitoring for sudden changes in SMART values and disk temperatures.

When I see that a new version of the package is available, a side effect of this is that it requires me to manually exit CrystalDiskInfo before kicking off the package upgrade process. If I fail to do so, the upgrade will likely fail due to being unable to overwrite resources currently in use. This changeset is intended to facilitate a smoother upgrade experience.

## How Has this Been Tested?
### Environments
#### Dev
* OS Build: Windows 11 Pro v10.0.22000.0 (64-bit)
* PowerShell version: 7.2.4
* Chocolatey version: 1.1.0
#### Chocolatey Test Environment
* Vagrant Box Version: 2.0.0
* VM Provider: Hyper-V
* OS Build: Windows Server 2012 R2 Datacenter v6.3.9600.0 (64-bit)
* PowerShell version: 4.0
* Chocolatey version: 1.1.0

### Steps

#### Preparation
1. Download `CrystalDiskInfo8_17_2.zip`, and copy to `crystaldiskinfo.portable`'s `tools` directory, as the archive is not committed to this repository.
2. Bump Nuspec's version for both `crystaldiskinfo` and `crystaldiskinfo.portable` using package fix notation (not included in this changeset, as this change is not critical and can wait for the next release).
3. Bump `crystaldiskinfo`'s version dependency on `crystaldiskinfo.portable` to the same version.
4. Create test packages using `choco pack`.
5. Copy both packages to the same directory.
6. Install/upgrade to meta test package (e.g. `choco upgrade crystaldiskinfo --source=.`).
7. Confirm package install succeeds.

#### Starting Processes

##### Starting DiskInfo(32|64).exe
1. Simply start CrystalDiskInfo using the created shortcut or an appropriate shim.

##### Starting AlertMail(4|48).exe
1. In CrystalDiskInfo, select Function > Alert Features > Mail Settings.

##### Starting opusdec.exe
**NOTE:** This is an [off-the-shelf OPUS file decoder](https://opus-codec.org/docs/opus-tools/opusdec.html) redistributed with the program. It is very difficult to reliably ensure this is running in the context that CrystalDiskInfo consumes it (i.e. [exporting an OPUS file to a WAV file](https://github.com/hiyohiyo/CrystalDiskInfo/blob/bc4c05e30ec0d7dc9a1e99c482b2f670e22e266a/DiskInfoDlg.cpp#L1899)). Doing so depends on a combination of a disk alert condition being triggered, an OPUS file being configured as the sound to be played back, and being able to execute the package upgrade before the export completes. Therefore, I tested using other functionality this executable exposes instead.

1. If running in the Chocolatey Test Environment, enable the Windows Audio service:
```ps1
Start-Service -Name "Audiosrv"
```
2. In a separate elevated session, play back a sufficiently long OPUS file:
```ps1
Push-Location "C:\ProgramData\chocolatey\lib\crystaldiskinfo.portable\tools\CdiResource\opus"
.\opusdec.exe "D:\Local\Downloads\sample3.opus"
```
[Example OPUS files](https://filesamples.com/formats/opus)

#### Test Cases

##### Uninstall
**NOTE:** This tests execution via `chocolateyBeforeModify.ps1`.
1. Start all package processes using steps defined above.
2. Uninstall the meta package (e.g. `choco uninstall crystaldiskinfo`).
5. Respond to run-time prompt to confirm desired uninstallation of `crystaldiskinfo.portable`.
6. Confirm processes are all terminated without issues, and that the package uninstall succeeds.

##### Upgrade via Portable Package
**NOTE:** This will also test execution via `chocolateyBeforeModify.ps1`.
1. Install the portable test package (e.g. `choco install crystaldiskinfo.portable --source=.`).
2. Start all package processes using steps defined above.
3. Force-upgrade the portable package to the test package (`choco upgrade crystaldiskinfo.portable --source=. --force`).
4. Confirm processes are all terminated without issues, and that the package upgrade succeeds.

##### Upgrade via Meta Package
**NOTE:** This will NOT execute `chocolateyBeforeModify.ps1`, and depends on `chocolateyInstall.ps1`'s execution.
1. Uninstall portable test package (e.g. `choco uninstall crystaldiskinfo.portable`).
2. Install current meta package (e.g. `choco install crystaldiskinfo`).
3. Start all package processes using steps defined above.
4. Upgrade the meta package to the test meta package (`choco upgrade crystaldiskinfo --source=.`).
7. Confirm processes are all terminated without issues, and that the package upgrade succeeds.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
