### PR TITLE
(exiftool) Ensure old files are removed on package upgrade

### DIFF
--- a/automatic/exiftool/tools/chocolateyBeforeModify.ps1
+++ b/automatic/exiftool/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,16 @@
+﻿$ErrorActionPreference = 'Stop';
+
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$packageDir = "$($toolsDir | Split-Path -parent)"
+
+Get-ChildItem -Path "$packageDir" -filter exiftool-*.txt | Foreach-Object {
+  $zipArchive = $_.Name -Match '(?<Archive>^.*zip)' | foreach-object { $Matches.Archive }
+  Uninstall-ChocolateyZipPackage 'exiftool' "$zipArchive"
+  Remove-Item -Path $_.FullName
+}
+
+$link = Get-Item -Path "$(Join-Path $toolsDir 'exiftool.exe')"
+
+if (($null -ne $link) -And (Test-Path -Path $link -PathType Leaf)) {
+  $link.Delete()
+}

--- a/automatic/exiftool/tools/chocolateyInstall.ps1
+++ b/automatic/exiftool/tools/chocolateyInstall.ps1
@@ -6,8 +6,8 @@ $checksum     = 'ba7b8a089b654ef4822af543e9724e1ddd05877b077fa8aeeb3bd1096e4234a
 $checksumType = 'sha256'
 
 $packageArgs = @{
-  packageName    = $env:ChocolateyPackageName
-  unzipLocation  = $toolsDir
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
   url           = $url
   checksum      = $checksum
   checksumType  = $checksumType
@@ -15,4 +15,4 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage  @packageArgs
 
-Move-Item "$(Join-Path $toolsDir 'exiftool(-k).exe')" "$(Join-Path $toolsDir 'exiftool.exe')" -Force
+New-Item -ItemType SymbolicLink -Path "$(Join-Path $toolsDir 'exiftool.exe')" -Target "$(Join-Path $toolsDir 'exiftool(-k).exe')" -Force


### PR DESCRIPTION
## Description
Zip content files created by `Install-ChocolateyZipPackage` remain after package upgrade.  Expected behavior is for these content files to be removed.

Added handing in `chocolateyBeforeModify.ps1` to call on the `Uninstall-ChocolateyZipPackage` helper function to remove the contents of any unpacked archives and remove the content file.

Modified the handling of the archive contents to use a symbolic link `exiftool.exe` pointing to the extracted executable `exiftool(-k).exe` rather than renaming it.  The symbolic link will be picked up and have the shim generated on package install/update.

## Motivation and Context
Ensure old package files are removed on upgrade.

Fixes #125

## How Has this Been Tested?
* Tested package installs in a local [Chocolatey test environment](https://github.com/majkinetor/chocolatey-test-environment)
to validate no impact on installs.
* Examined directory contents post upgrade to ensure no files remaining from previous upgrade.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
