### PR TITLE
(nginx) Fix installation script

### DIFF
--- a/automatic/nginx/tools/helpers.ps1
+++ b/automatic/nginx/tools/helpers.ps1
@@ -25,7 +25,8 @@ function Assert-TcpPortIsOpen {
 }
 
 function Get-NginxInstallOptions {
-    $configFile = Join-Path $env:chocolateyPackageFolder 'config.xml'
+    $toolsDir = Split-Path -parent $MyInvocation.PSScriptRoot
+    $configFile = Join-Path $toolsDir 'config.xml'
     $config = Import-CliXml $configFile
 
     return $config
@@ -120,7 +121,8 @@ function Set-NginxInstallOptions {
         ServiceAccount = $arguments.ServiceAccount
     }
 
-    $configFile = Join-Path $env:chocolateyPackageFolder 'config.xml'
+    $toolsDir = Split-Path -parent $MyInvocation.PSScriptRoot
+    $configFile = Join-Path $toolsDir 'config.xml'
     Export-Clixml -Path $configFile -InputObject $config
 }
 

--- a/automatic/nginx/tools/helpers.ps1
+++ b/automatic/nginx/tools/helpers.ps1
@@ -25,8 +25,7 @@ function Assert-TcpPortIsOpen {
 }
 
 function Get-NginxInstallOptions {
-    $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
-    $configFile = Join-Path $toolsDir 'config.xml'
+    $configFile = Join-Path $env:chocolateyPackageFolder 'config.xml'
     $config = Import-CliXml $configFile
 
     return $config
@@ -121,8 +120,7 @@ function Set-NginxInstallOptions {
         ServiceAccount = $arguments.ServiceAccount
     }
 
-    $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition
-    $configFile = Join-Path $toolsDir 'config.xml'
+    $configFile = Join-Path $env:chocolateyPackageFolder 'config.xml'
     Export-Clixml -Path $configFile -InputObject $config
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
We should use PSScriptRoot property to fix nginx installation.

```
MyInvocation:
PSScriptRoot          : C:\ProgramData\chocolatey\lib\nginx\tools
PSCommandPath         : C:\ProgramData\chocolatey\lib\nginx\tools\helpers.ps1
InvocationName        : Set-NginxInstallOptions
```

Because Definition contains scriptblock:
```
Definition          :
                          [CmdletBinding()]
                          param(
                              [Parameter(Position = 0, Mandatory)][ValidateNotNullOrEmpty()][PSCustomObject] $arguments
                          )

                          $nginxPaths = Get-NginxPaths $arguments.destination
```

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

```
ERROR: Cannot bind argument to parameter 'Path' because it is an empty string.
 at Set-NginxInstallOptions, C:\ProgramData\chocolatey\lib\nginx\tools\helpers.ps1: line 125
at Install-Nginx, C:\ProgramData\chocolatey\lib\nginx\tools\helpers.ps1: line 64
at <ScriptBlock>, C:\ProgramData\chocolatey\lib\nginx\tools\chocolateyInstall.ps1: line 19
at <ScriptBlock>, C:\ProgramData\chocolatey\helpers\chocolateyScriptRunner.ps1: line 49
at <ScriptBlock>, <No file>: line 1


Failures
 - nginx (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\nginx\tools\chocolateyInstall.ps1'.
 See log for details.
Sending message 'PostRunMessage' out if there are subscribers...
Exiting with -1
```
## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Run choco locally


```
PS > choco install -y C:\chocolatey-packages\automatic\nginx\nginx.nuspec

Only an exit code of non-zero will fail the package by default. Set
 `--failonstderr` if you want error messages to also fail a script. See
 `choco -h` for details.
 The install of nginx was successful.
  Software installed to 'C:\tools'

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
```
## Screenshot (if appropriate, usually isn't needed):
![image](https://user-images.githubusercontent.com/47745270/197341847-c0f76f03-a593-4518-a8b6-6b3c7b2ef308.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
