### PR TITLE
(jetbrainstoolbox) advertise product to current user for background service installations

### DIFF
--- a/automatic/jetbrainstoolbox/tools/chocolateyinstall.ps1
+++ b/automatic/jetbrainstoolbox/tools/chocolateyinstall.ps1
@@ -6,15 +6,15 @@ $checksum     = '831cb3ced25598faf6e364748b9d4e3a19f582034c6b2190dace01b6d526572
 $checksumType = 'sha256'
 
 $packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
-  softwareName  = 'JetBrains Toolbox*'
-  fileType      = 'exe'
-  silentArgs   = '/S'
-  validExitCodes= @(0)
+  packageName    = $env:ChocolateyPackageName
+  softwareName   = 'JetBrains Toolbox*'
+  fileType       = 'exe'
+  silentArgs     = '/S /ju'
+  validExitCodes = @(0)
   url            = $url
   checksum       = $checksum
   checksumType   = $checksumType
-  destination   = $toolsDir
+  destination    = $toolsDir
 }
 
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change will adjust the installation of the JetBrains Toolbox to advertise the product to the current user.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

This fixes an issue when using the Chocolatey background service for installing this software.
The JetBrains Toolbox is a per-user installation, when using the Chocolatey background service
the software is only installed for the `ChocolateyLocalAdmin` user, with the `/ju` MSI flag it will
get advertised to the user invoking the installation and be available for them as well.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

This has been tested in our cooperate environment using Chocolatey for Business, using the
background service. A sandbox VM was used to test the change without using the background
service, the behaviour there is untouched.

This change has also been tested using the `/jm` flag, while the Microsoft documentation
states that this will advertise the product machine wide, this didn't seem to work in practice
in my tests.

## Screenshot (if appropriate, usually isn't needed):

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
