### PR TITLE
(iobit-uninstaller) Add '/NoDesktopIcon' package parameter

### DIFF
--- a/automatic/iobit-uninstaller/README.md
+++ b/automatic/iobit-uninstaller/README.md
@@ -16,6 +16,10 @@ Regular uninstall cannot delete programs completely. With IObit Uninstaller, you
 
 Outdated software is risky. Attacker can easy find weakness in it resulting whole system at danger. IObit Uninstaller 8 Free is there keeping over 60 critical programs up to date for you. You can easily update software via secure download links to the latest version on publishers’ websites.
 
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install iobit-uninstaller --params "/NoDesktopIcon"`
+
 **Please Note**: This is an automatically updated package. If you find it is
 out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.

--- a/automatic/iobit-uninstaller/iobit-uninstaller.nuspec
+++ b/automatic/iobit-uninstaller/iobit-uninstaller.nuspec
@@ -63,6 +63,10 @@ Regular uninstall cannot delete programs completely. With IObit Uninstaller, you
 
 Outdated software is risky. Attacker can easy find weakness in it resulting whole system at danger. IObit Uninstaller 8 Free is there keeping over 60 critical programs up to date for you. You can easily update software via secure download links to the latest version on publishers’ websites.
 
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install iobit-uninstaller --params "/NoDesktopIcon"`
+
 **Please Note**: This is an automatically updated package. If you find it is
 out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.

--- a/automatic/iobit-uninstaller/tools/chocolateyInstall.ps1
+++ b/automatic/iobit-uninstaller/tools/chocolateyInstall.ps1
@@ -4,6 +4,8 @@ $url          = 'https://cdn.iobit.com/dl/iobituninstaller.exe'
 $checksum     = '8E36F365AA367D174901B6ADD2966F4CFAC58039A4C6724B3DD07C57B001C8D0'
 $checksumType = 'sha256'
 
+. $toolsDir\helpers.ps1
+
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   softwareName  = 'IObit Uninstaller*'
@@ -15,5 +17,9 @@ $packageArgs = @{
   checksumType  = $checksumType
   destination   = $toolsDir
 }
+
+$pp = Get-PackageParameters
+$mergeTasks = Get-MergeTasks $pp
+$packageArgs.silentArgs += ' /MERGETASKS="{0}"' -f $mergeTasks
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/iobit-uninstaller/tools/helpers.ps1
+++ b/automatic/iobit-uninstaller/tools/helpers.ps1
@@ -21,3 +21,10 @@ function Close-Iobit {
         GetProc $Proccess | Stop-Process -Force
     }
 }
+function Get-MergeTasks([hashtable] $pp) {
+    $tasks = @()
+    $tasks += '!'* $pp.NoDesktopIcon     + 'desktopicon'
+
+    Write-Host "Merge Tasks: $tasks"
+    return $tasks -join ','
+}


### PR DESCRIPTION
Allows for disabling desktop icon/shortcut
## Description
Sets the /MERGETASKS parameter that iobit-uninstaller uses for the desktop icon task
If '/NoDesktopIcon' is not set:
		* /MERGETASKS='destkopicon'
If '/NoDesktopIcon' is set:
		* /MERGETASKS='!destkopicon'

## Motivation and Context
Allows to disable/enable the desktop icon. Some people dislike having their desktop cluttered by these thing.

## How Has this Been Tested?
I've installed the package several times, finding it worked. And it's had no effect on the program; it's just a change related to the icon. Though, I haven't done this in the test environment. I'm currently on a computer that I can't get the test environment to work on.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [X] My change requires a change to documentation (this usually means the notes in the description of a package).
- [X] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [X] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
