### PR TITLE
(samsung-magician) Fix blocking issues with AHK v1 script

### DIFF
--- a/automatic/samsung-magician/tools/chocolateyInstall.ahk
+++ b/automatic/samsung-magician/tools/chocolateyInstall.ahk
@@ -15,10 +15,6 @@ WinActivate
 ; Language selection
 ControlClick, OK, Select Setup Language,,,, NA
 
-; GDPR or not license
-WinWait, Setup, European
-ControlClick, &No, Setup,,,, NA
-
 ; Welcome screen
 WinWait, %winTitleInstall%
 ControlClick, &Next >, %winTitleInstall%,,,, NA

--- a/automatic/samsung-magician/tools/chocolateyInstall.ahk
+++ b/automatic/samsung-magician/tools/chocolateyInstall.ahk
@@ -17,21 +17,21 @@ ControlClick, OK, Select Setup Language,,,, NA
 
 ; Welcome screen
 WinWait, %winTitleInstall%
-ControlClick, &Next >, %winTitleInstall%,,,, NA
+ControlClick, &Next, %winTitleInstall%,,,, NA
 
 ; License terms
 WinWait, %winTitleInstall%, License Agreement
 ControlClick, I &accept the agreement, %winTitleInstall%,,,, NA
-ControlClick, &Next >, %winTitleInstall%,,,, NA
+ControlClick, &Next, %winTitleInstall%,,,, NA
 
 ; Collection and Use of Personal Information
 WinWait, %winTitleInstall%, Collection and Use
 ControlClick, I &accept the agreement, %winTitleInstall%,,,, NA
-ControlClick, &Next >, %winTitleInstall%,,,, NA
+ControlClick, &Next, %winTitleInstall%,,,, NA
 
 ; Icons
 WinWait, %winTitleInstall%, Select Additional
-ControlClick, &Next >, %winTitleInstall%,,,, NA
+ControlClick, &Next, %winTitleInstall%,,,, NA
 
 WinWait, %winTitleInstall%, Ready to Install
 ControlClick, &Install, %winTitleInstall%,,,, NA


### PR DESCRIPTION
## Description
This changeset tweaks the package's AutoHotKey install script to reflect changes made in more recent releases to the installer.

## Motivation and Context
While regression testing a fix for #167, I noticed there were a couple issues with the current v1-compatible script that needed to be fixed. I felt this deserved a PR in its own right, as I didn't want to lump it into the v2 conversion effort.

Samsung has made a couple breaking changes that impacted the AutoHotKey script. Specifically:
* v6.3.0.300 removed the dialog prompt that asked users to confirm whether they were a resident of a GDPR country:
![GDPR Dialog screenshot](https://user-images.githubusercontent.com/6869577/218918332-a5eb569a-c6b1-4bf7-924a-95af225e7521.png)
This caused `WinWait, Setup, European` to block the script by waiting for a dialog that will not show up.
  * Resolved by removing the section relating to this dialog.
* v.7.0.0.510 (published as package v7.0) removed the right-angle bracket character (`>`) from the Next button's string, which results in a silent `ControlClick` failure on the welcome dialog.
  * Resolved by correcting each instance of the string for consistency.

Both of these issues normally would've caused Package Verifier to fail, but these slipped through since the package is currently exempted.

## How Has this Been Tested?
### Environments
#### Dev
* OS Build: Windows 11 Pro v10.0.22621.0 (64-bit)
* PowerShell version: 7.3.2
* Chocolatey version: 1.2.1
#### Chocolatey Test Environment
* Vagrant Box Version: 3.0.0
* VM Provider: Virtualbox (although practically Hyper-V, since I manually converted the resulting virtual disk)
* OS Build: Windows Server 2019 Datacenter v10.0.17763.0 (64-bit)
* PowerShell version: 5.1.17763.3770
* Chocolatey version: 1.2.1

### Steps
1. Created a test package that consumes the modified script (i.e. `choco pack`).
2. Install/downgrade to AutoHotKey v1.1 to satisfy current package dependency while avoiding current v2-related failures (i.e. `choco install autohotkey.portable --version=1.1.36.02 --allow-downgrade`).
3. Install test package version with backup source to accommodate `dotnet4.6.1` dependency (i.e. `choco install samsung-magician --source="'.;https://community.chocolatey.org/api/v2/'"`).
4. Confirm the AutoHotKey script executes successfully, and guides the installer to completion without requiring manual user input.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
