### PR TITLE
(samsung-magician) Add support for upgrade/reinstall operations

### DIFF
--- a/automatic/samsung-magician/tools/chocolateyInstall.ahk
+++ b/automatic/samsung-magician/tools/chocolateyInstall.ahk
@@ -3,7 +3,7 @@
 #Warn  ; Enable warnings to assist with detecting common errors.
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
-SetTitleMatchMode, 1
+SetTitleMatchMode, Regex
 SetControlDelay -1
 
 winTitleInstall = Setup - Samsung Magician
@@ -15,8 +15,16 @@ WinActivate
 ; Language selection
 ControlClick, OK, Select Setup Language,,,, NA
 
-; Welcome screen
-WinWait, %winTitleInstall%
+; Wait for either the overwrite confirmation dialog (for existing installs) or the Welcome screen (for new installs)
+WinWait, ahk_class i)#32770|TWizardForm ahk_exe Samsung_Magician_installer.tmp
+if WinExist("ahk_class #32770 ahk_exe Samsung_Magician_installer.tmp") {
+  ; Overwrite confirmation dialog
+  ControlClick, Button1, ahk_class #32770 ahk_exe Samsung_Magician_installer.tmp,,,, NA
+
+  ; Welcome screen
+  WinWait, ahk_class TWizardForm ahk_exe Samsung_Magician_installer.tmp
+}
+
 ControlClick, &Next, %winTitleInstall%,,,, NA
 
 ; License terms


### PR DESCRIPTION
## Description

This changeset enhances the AutoHotKey install script to look for a dialog that is shown only when there is an existing Samsung Magician installation, and if shown, sends the necessary input to progress the installation process.

## Motivation and Context

If the installer detects an eligible existing installation of Samsung Magician, the following dialog will be shown after the Language Selection dialog:

![Samsung Magician Overwrite Dialog screenshot](https://user-images.githubusercontent.com/6869577/218952233-d832be32-2d2f-44ef-bd20-eb043d4fb6bc.png)

This will be shown if the version being installed is either newer or the same version. Downgrades are not directly supported and require the user to manually uninstall first.

The AutoHotkey script currently only supports the new install workflow, and will block while `WinWait`ing for the Welcome screen. Notably, this prevents completely automated upgrades or forced reinstallations. Consequently, manual user input to press the Yes button is required to nudge the script along.

Partially addresses #156. Another PR will be required to address language-related incompatibilities.

## How Has this Been Tested?

### Environments

#### Dev

* OS Build: Windows 11 Pro v10.0.22621.0 (64-bit)
* PowerShell version: 7.3.2
* Chocolatey version: 1.3.0

#### Chocolatey Test Environment
* Vagrant Box Version: 3.0.0
* VM Provider: Virtualbox (although practically Hyper-V, since I manually converted the resulting virtual disk)
* OS Build: Windows Server 2019 Datacenter v10.0.17763.0 (64-bit)
* PowerShell version: 5.1.17763.3770
* Chocolatey version: 1.3.0

### Steps
> **Note**
> **Prerequisite:** Samsung Magician (both the package and software) should **NOT** be installed. Otherwise, you may encounter issues with an attempted software downgrade or an undesired AHK v2 installation/upgrade.

1. Created a test package that consumes the modified script (i.e. `choco pack`).
2. Install/downgrade to AutoHotKey v1.1 to satisfy current package dependency while avoiding current v2-related failures (i.e. `choco install autohotkey.portable --version=1.1.36.02 --allow-downgrade`).
3. Install a previous version of Samsung Magician (e.g. `choco install samsung-magician --version=6.0.0`)
  > **Note**
  > Additional manual user input may be required for later package versions.
  > For versions [6.1.0, 6.3.0.301], users may be prompted to install Visual C++ Redistributable for Visual Studio 2015 (i.e. `vcredist140` v14.0.23026.0 or later) if not currently installed. No support for this existed in either the package's dependencies or the AutoHotkey script.
  > v6.3.0.301 or later introduced at least one AHK-breaking change that was fixed with #172.
4. Upgrade to the test package version (i.e. `choco upgrade samsung-magician --source="'.'"`).
5. Confirm the AutoHotKey script executes successfully, and guides the installer to completion without requiring manual user input.
6. Forcibly reinstall the test package version (i.e. `choco install samsung-magician --source="'.'" --force`).
7. Repeat step 5.
8. Uninstall Samsung Magician to prepare for a clean install test (i.e. `choco uninstall samsung-magician`).
9. Reinstall the test package version to regression test clean installs (i.e. `choco install samsung-magician --source="'.'"`).
10. Repeat step 5.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
