### PR TITLE
(samsung-magician) Add package support for software downgrades

### DIFF
--- a/automatic/samsung-magician/tools/chocolateyInstall.ps1
+++ b/automatic/samsung-magician/tools/chocolateyInstall.ps1
@@ -1,9 +1,18 @@
 ﻿$ErrorActionPreference = 'Stop'
 
-$toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url          = 'https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_Installer_Official_7.3.0.1100.zip'
-$checksum     = 'e8883664bb305619cd024de4fa8804b0c7a1d4a4987762afe4d22a033fa46b04'
-$checksumType = 'sha256'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+. $toolsDir\helpers.ps1
+
+$url                       = 'https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_Installer_Official_7.3.0.1100.zip'
+$checksum                  = 'e8883664bb305619cd024de4fa8804b0c7a1d4a4987762afe4d22a033fa46b04'
+$checksumType              = 'sha256'
+[version] $softwareVersion = '7.3.0.1100'
+
+$installedVersion = Get-InstalledVersion
+if ($installedVersion -gt $softwareVersion) {
+  Write-Output "Current installed version (v$installedVersion) must be uninstalled first..."
+  Uninstall-CurrentVersion
+}
 
 $packageArgs = @{
   PackageName    = $env:ChocolateyPackageName

--- a/automatic/samsung-magician/tools/chocolateyuninstall.ps1
+++ b/automatic/samsung-magician/tools/chocolateyuninstall.ps1
@@ -1,32 +1,5 @@
 ﻿$ErrorActionPreference = 'Stop'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+. $toolsDir\helpers.ps1
 
-$packageArgs = @{
-  packageName   = $env:ChocolateyPackageName
-  softwareName  = 'Samsung Magician*'
-  fileType      = 'exe'
-  silentArgs    = '/SILENT'
-  validExitCodes= @(0, 3010, 1605, 1614, 1641)
-}
-
-$uninstalled = $false
-[array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
-
-if ($key.Count -eq 1) {
-  $key | ForEach-Object {
-    $packageArgs['file'] = "$($_.UninstallString)"
-    if ($packageArgs['fileType'] -eq 'MSI') {
-      $packageArgs['silentArgs'] = "$($_.PSChildName) $($packageArgs['silentArgs'])"
-
-      $packageArgs['file'] = ''
-    }
-
-    Uninstall-ChocolateyPackage @packageArgs
-  }
-} elseif ($key.Count -eq 0) {
-  Write-Warning "$packageName has already been uninstalled by other means."
-} elseif ($key.Count -gt 1) {
-  Write-Warning "$($key.Count) matches found!"
-  Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
-  Write-Warning "Please alert package maintainer the following keys were matched:"
-  $key | ForEach-Object {Write-Warning "- $($_.DisplayName)"}
-}
+Uninstall-CurrentVersion

--- a/automatic/samsung-magician/tools/helpers.ps1
+++ b/automatic/samsung-magician/tools/helpers.ps1
@@ -1,0 +1,44 @@
+﻿$softwareNamePattern = 'Samsung Magician*'
+
+function Get-InstalledVersion {
+  [array] $keys = Get-UninstallRegistryKey -SoftwareName $softwareNamePattern
+
+  if ($keys.Length -ge 1) {
+      return [version] ($keys[0].DisplayVersion)
+  }
+
+  return $null
+}
+
+function Uninstall-CurrentVersion {
+  $packageArgs = @{
+    packageName   = $env:ChocolateyPackageName
+    softwareName  = $softwareNamePattern
+    fileType      = 'exe'
+    silentArgs    = '/SILENT'
+    validExitCodes= @(0, 3010, 1605, 1614, 1641)
+  }
+
+  [array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
+
+  if ($key.Count -eq 1) {
+    $key | ForEach-Object {
+      $packageArgs['file'] = "$($_.UninstallString)"
+      if ($packageArgs['fileType'] -eq 'MSI') {
+        $packageArgs['silentArgs'] = "$($_.PSChildName) $($packageArgs['silentArgs'])"
+
+        $packageArgs['file'] = ''
+      }
+
+      Uninstall-ChocolateyPackage @packageArgs
+    }
+  } elseif ($key.Count -eq 0) {
+    Write-Warning "$packageName has already been uninstalled by other means."
+  } elseif ($key.Count -gt 1) {
+    Write-Warning "$($key.Count) matches found!"
+    Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+    Write-Warning "Please alert package maintainer the following keys were matched:"
+    $key | ForEach-Object {Write-Warning "- $($_.DisplayName)"}
+  }
+}
+

--- a/automatic/samsung-magician/update.ps1
+++ b/automatic/samsung-magician/update.ps1
@@ -8,6 +8,7 @@ function global:au_SearchReplace {
             "(^[$]url\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
             "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
             "(^[$]checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+            "(^\[version\] [$]softwareVersion\s*=\s*)('.*')" = "`$1'$($Latest.RemoteVersion)'"
         }
      }
 }
@@ -23,6 +24,7 @@ function global:au_GetLatest {
     $version = (Get-Version $version).ToString()
 
     return @{
+        RemoteVersion = $version
         URL32 = $url
         Version = $version
     }


### PR DESCRIPTION
## Description
This changeset enhances the install script to detect the current installed version of Samsung Magician, and if necessary, uninstalls the current version of Samsung Magician to enable a downgrade operation to succeed.

## Motivation and Context
If the installer detects the current installed version of Samsung Magician is newer than the installer's version, the following dialog will be shown after the Language Selection dialog:

![Samsung Magician Downgrade](https://user-images.githubusercontent.com/6869577/224516363-885fd533-8e9a-4b83-9094-de393669686d.png)

When dismissed, the installer will return exit code 1, causing the install script to fail. The user must uninstall Samsung Magician before reattempting to install that specific version.

To implement proper support for the install command's `--allow-downgrade` switch, the script needs awareness of this requirement and to act accordingly for downgrade scenarios.

## How Has this Been Tested?

#### Dev

* OS Build: Windows 11 Pro v10.0.22621.0 (64-bit)
* PowerShell version: 7.3.3
* Chocolatey version: 1.3.0

#### Chocolatey Test Environment
* Vagrant Box Version: 3.0.0
* VM Provider: Virtualbox (although practically Hyper-V, since I manually converted the resulting virtual disk)
* OS Build: Windows Server 2019 Datacenter v10.0.17763.0 (64-bit)
* PowerShell version: 5.1.17763.3770
* Chocolatey version: 1.3.0

### Steps

#### Test Package Creation

1. Created a test package of the current version that consumes the modified scripts (i.e. `choco pack`).
2. Create a test package version for a past version with a similar patch applied (reference commit reverting to v7.2.0.930 available at https://github.com/brogers5/chocolatey-packages-mkevenaar/commit/942e992f4c55bdff91ea17cfe2045da58a807112).
3. Repeat step 1 with the forked past package version.

#### Downgrade Test
1. Install the latest version of Samsung Magician (i.e. `choco install samsung-magician`).
2. Install the past test package version (i.e. `choco install samsung-magician --source="'.;https://community.chocolatey.org/api/v2/'" --version=7.2.0.930 --allow-downgrade`).
3. Confirm the current version of Samsung Magician is uninstalled without issues.
4. Confirm the package installation completes without errors.

#### Uninstall Regression Test
1. Uninstall the past test package (i.e. `choco uninstall samsung-magician`).
2. Confirm the uninstallation completes without errors.

#### Clean Install Regression Test
1. Install the past test package version (i.e. `choco install samsung-magician --source="'.'" --version=7.2.0.930`).
2. Confirm the package installation completes without errors.

#### Reinstall Regression Test
1. Forcibly reinstall the past test package version (i.e. `choco install samsung-magician --source="'.'" --version=7.2.0.930 --force`).
2. Monitor the installation process, and confirm the current installation is not uninstalled first.
3. Confirm the package installation completes without errors.

#### Upgrade Regression Test
1. Upgrade to the current test package version (i.e. `choco upgrade samsung-magician --source="'.'"`).
2. Monitor the installation process, and confirm the current installation is not uninstalled first.
3. Confirm the package upgrade completes without errors.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
