### PR TITLE
(googledrive) Add releaseNotes URL

### DIFF
--- a/automatic/googledrive/googledrive.nuspec
+++ b/automatic/googledrive/googledrive.nuspec
@@ -52,6 +52,7 @@ Choose folders on your computer to sync with Google Drive or backup to Google Ph
 out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.
 ]]></description>
+    <releaseNotes>https://support.google.com/a/answer/7577057</releaseNotes>
     <!-- =============================== -->
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->


### PR DESCRIPTION
## Description
This changeset adds `googledrive`'s release notes URL, as published and maintained by Google, to the package's metadata.

## Motivation and Context
Fairly self-explanatory change. Adding the `releaseNotes` tag with the URL to the Nuspec, to ensure it's readily available from the package page on the Community Repository.

## How Has this Been Tested?
`choco pack`ed with the modified Nuspec.

Opened the resulting package with NuGet Package Explorer, and confirmed the Release Notes section populates as expected.

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
