### PR TITLE
(mongodb) Fixed removed feature from MSI

### DIFF
--- a/automatic/mongodb.install/tools/chocolateyInstall.ps1
+++ b/automatic/mongodb.install/tools/chocolateyInstall.ps1
@@ -3,7 +3,7 @@ $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url64          = 'https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-6.3.0-rc1-signed.msi'
 $checksum64     = 'c5bd93e51def6c3a5cf45296cdbf96b85d2cd638fa417cc137d39f1d2bcd4320'
 $checksumType64 = 'sha256'
-$silentArgs     = 'ADDLOCAL="ServerService,Server,ProductFeature,Client,Router,MiscellaneousTools" /qn /norestart'
+$silentArgs     = 'ADDLOCAL="ServerService,Server,ProductFeature,Router,MiscellaneousTools" /qn /norestart'
 $dataPath       = "$env:PROGRAMDATA\MongoDB\data\db"
 $logPath        = "$env:PROGRAMDATA\MongoDB\log"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
In order to fix #166, the feature Client doesn't exit anymore in the MSI Package. The MSI Package is now providing Mongo Compass as the default client to access MongoDB. They created a new feature called "LegacyClient" if you want to keep the old client but I guess this is not the case here.

## Motivation and Context
Fixes #166 for at least new version of this package !

## How Has this Been Tested?
Run the script on my local computer.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [X] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
