### PR TITLE
googledrive: add /NoGsuiteIcons option to disable creation of google suite shortcuts

### DIFF
--- a/automatic/googledrive/README.md
+++ b/automatic/googledrive/README.md
@@ -6,7 +6,8 @@ Choose folders on your computer to sync with Google Drive or backup to Google Ph
 
 ## Package Parameters
 
-* `/NoStart` - Do not start Google Drive after installation.
+- `/NoStart` - Do not start Google Drive after installation.
+- `/NoGsuiteIcons` - Do not create Google Suite shortcuts on desktop.
 
 **Please Note**: This is an automatically updated package. If you find it is
 out of date by more than a day or two, please contact the maintainer(s) and

--- a/automatic/googledrive/tools/chocolateyInstall.ps1
+++ b/automatic/googledrive/tools/chocolateyInstall.ps1
@@ -35,6 +35,9 @@ else {
   if ($pp.NoStart) {
     $packageArgs['silentArgs'] += ' --skip_launch_new'
   }
+  if ($pp.NoGsuiteIcons) {
+    $packageArgs['silentArgs'] += ' --gsuite_shortcuts=false'
+  }
 
   Install-ChocolateyPackage @packageArgs
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
With this option google drive installer will not create create this shortcuts on desktop:
![Screenshot 2023-04-15 204202](https://user-images.githubusercontent.com/5204968/232244877-68391cbc-c632-4e3c-8ce7-45bb345bfe0e.png)

## Motivation and Context
Some users (like me) will not need this icons.

## How Has this Been Tested?
`choco pack`
`sudo choco install -y --force --params "/NoGsuiteIcons" --verbose googledrive --version 73.0.4.0 --source .`

## Screenshot (if appropriate, usually isn't needed):
GUI installer have option to stop creating this icons.
![Screenshot 2023-04-15 204119](https://user-images.githubusercontent.com/5204968/232244913-a02d38d6-4a06-411e-94fe-c68a20851c88.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
