### PR TITLE
(microsoft-windows-terminal) Fix update.ps1

### DIFF
--- a/automatic/microsoft-windows-terminal/update.ps1
+++ b/automatic/microsoft-windows-terminal/update.ps1
@@ -42,7 +42,7 @@ function global:au_GetLatest {
       }
 
       $version = Get-Version $version
-      $asset = $release.assets | Where-Object -Property name -like "${re}_Win10_*.msixbundle" | Where-Object -Property name -Match $fileVersion
+      $asset = $release.assets | Where-Object -Property name -like "${re}_*.msixbundle" | Where-Object -Property name -Match $fileVersion
       if ($asset) {
         $url = $asset.browser_download_url
         $streams.Add($re, (CreateStream $url $version))


### PR DESCRIPTION
## Description

Since version 1.17.11391.0, Windows 10 and Windows 11 packages are rejoined [1], and the `win10` pattern in filenames are gone.

Fixes https://github.com/mkevenaar/chocolatey-packages/issues/198

[1] https://github.com/microsoft/terminal/releases/tag/v1.17.11391.0

## Motivation and Context

Get the latest Microsoft Terminal automatically https://github.com/mkevenaar/chocolatey-packages/issues/198

## How Has this Been Tested?

```
PS> .\update.ps1
microsoft-windows-terminal - checking updates using au version 2022.10.24

*** Stream: Microsoft.WindowsTerminal ***
URL check
  https://github.com/microsoft/terminal/releases/download/v1.17.11461.0/Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle
nuspec version: 1.16.10261.0
remote version: 1.17.11461.0
New version is available
Automatic checksum skipped
Running au_BeforeUpdate
Purging msixbundle
Downloading to Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle - https://github.com/microsoft/terminal/releases/download/v1.17.11461.0/Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle
Setting package description from README.md
Updating files
  $Latest data:
    Checksum32                (String)     E3A5A581F2A404D9D97F6826890BE9FD7BFC827498035D6C45E1C12F9D2D4E8F
    ChecksumType32            (String)     sha256
    FileName32                (String)     Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle
    FileType                  (String)     msixbundle
    NuspecVersion             (String)     1.16.10261.0
    PackageName               (String)     microsoft-windows-terminal
    PreRelease                ()           False
    RemoteVersion             (String)     1.17.11461.0
    Stream                    (String)     Microsoft.WindowsTerminal
    Streams                   (Hashtable)  System.Collections.Hashtable
    URL32                     (String)     https://github.com/microsoft/terminal/releases/download/v1.17.11461.0/Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle
    Version                   (AUVersion)  1.17.11461.0
  microsoft-windows-terminal.nuspec
    setting id: microsoft-windows-terminal
    updating version: 1.16.10261.0 -> 1.17.11461.0
  .\tools\chocolateyInstall.ps1
    (^[$]fileName\s*=\s*"[$]toolsDir\\).* = ${1}Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle"
    (^[$]PreRelease\s*=\s*)".*"         = ${1}"False"
    (^[$]version\s*=\s*)".*"            = ${1}"1.17.11461.0"
  .\legal\VERIFICATION.txt
    (?i)(checksum32:).*                 = ${1} E3A5A581F2A404D9D97F6826890BE9FD7BFC827498035D6C45E1C12F9D2D4E8F
    (?i)(listed on\s*)\<.*\>            = ${1}<https://api.github.com/repos/microsoft/terminal/releases>
    (?i)(32-Bit.+)\<.*\>                = ${1}<https://github.com/microsoft/terminal/releases/download/v1.17.11461.0/Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle>
    (?i)(checksum type:).*              = ${1} sha256
  .\tools\chocolateyUninstall.ps1
    (^[$]PreRelease\s*=\s*)".*"         = ${1}"False"
Attempting to build package from 'microsoft-windows-terminal.nuspec'.
Successfully created package 'C:\Users\yen\Computer\windows\mkevenaar-chocolatey-packages\automatic\microsoft-windows-terminal\microsoft-windows-terminal.1.17.11461.nupkg'

*** Stream: Microsoft.WindowsTerminalPreview ***
URL check
  https://github.com/microsoft/terminal/releases/download/v1.18.1462.0/Microsoft.WindowsTerminalPreview_1.18.1462.0_8wekyb3d8bbwe.msixbundle
nuspec version: 1.17.1023-beta
remote version: 1.18.1462.0-beta
New version is available
Automatic checksum skipped
Running au_BeforeUpdate
Purging msixbundle
Downloading to Microsoft.WindowsTerminalPreview_1.18.1462.0_8wekyb3d8bbwe.msixbundle - https://github.com/microsoft/terminal/releases/download/v1.18.1462.0/Microsoft.WindowsTerminalPreview_1.18.1462.0_8wekyb3d8bbwe.msixbundle
Setting package description from README.md
Updating files
  $Latest data:
    Checksum32                (String)     60BF2D35DAC57DC2878C71C581CC3F000E1875A08AF318615E8FA6DD9288BCDA
    ChecksumType32            (String)     sha256
    FileName32                (String)     Microsoft.WindowsTerminalPreview_1.18.1462.0_8wekyb3d8bbwe.msixbundle
    FileType                  (String)     msixbundle
    NuspecVersion             (String)     1.17.1023-beta
    PackageName               (String)     microsoft-windows-terminal
    PreRelease                (Boolean)    True
    RemoteVersion             (String)     1.18.1462.0
    Stream                    (String)     Microsoft.WindowsTerminalPreview
    Streams                   (Hashtable)  System.Collections.Hashtable
    URL32                     (String)     https://github.com/microsoft/terminal/releases/download/v1.18.1462.0/Microsoft.WindowsTerminalPreview_1.18.1462.0_8wekyb3d8bbwe.msixbundle
    Version                   (AUVersion)  1.18.1462.0-beta
  microsoft-windows-terminal.nuspec
    setting id: microsoft-windows-terminal
    updating version: 1.17.1023-beta -> 1.18.1462.0-beta
  .\tools\chocolateyInstall.ps1
    (^[$]fileName\s*=\s*"[$]toolsDir\\).* = ${1}Microsoft.WindowsTerminalPreview_1.18.1462.0_8wekyb3d8bbwe.msixbundle"
    (^[$]PreRelease\s*=\s*)".*"         = ${1}"True"
    (^[$]version\s*=\s*)".*"            = ${1}"1.18.1462.0"
  .\legal\VERIFICATION.txt
    (?i)(checksum32:).*                 = ${1} 60BF2D35DAC57DC2878C71C581CC3F000E1875A08AF318615E8FA6DD9288BCDA
    (?i)(listed on\s*)\<.*\>            = ${1}<https://api.github.com/repos/microsoft/terminal/releases>
    (?i)(32-Bit.+)\<.*\>                = ${1}<https://github.com/microsoft/terminal/releases/download/v1.18.1462.0/Microsoft.WindowsTerminalPreview_1.18.1462.0_8wekyb3d8bbwe.msixbundle>
    (?i)(checksum type:).*              = ${1} sha256
  .\tools\chocolateyUninstall.ps1
    (^[$]PreRelease\s*=\s*)".*"         = ${1}"True"
Attempting to build package from 'microsoft-windows-terminal.nuspec'.
Successfully created package 'C:\Users\yen\Computer\windows\mkevenaar-chocolatey-packages\automatic\microsoft-windows-terminal\microsoft-windows-terminal.1.18.1462-beta.nupkg'

Package updated

Path          : C:\Users\yen\Computer\windows\mkevenaar-chocolatey-packages\automatic\microsoft-windows-terminal
Name          : microsoft-windows-terminal
Updated       : True
Pushed        : False
RemoteVersion : 1.18.1462.0-beta
NuspecVersion : 1.17.1023-beta
Result        : {microsoft-windows-terminal - checking updates using au version 2022.10.24, , *** Stream: Microsoft.WindowsTerminal ***, URL check…}
Error         :
NuspecPath    : C:\Users\yen\Computer\windows\mkevenaar-chocolatey-packages\automatic\microsoft-windows-terminal\microsoft-windows-terminal.nuspec
NuspecXml     : #document
Ignored       : False
IgnoreMessage :
StreamsPath   : C:\Users\yen\Computer\windows\mkevenaar-chocolatey-packages\automatic\microsoft-windows-terminal\microsoft-windows-terminal.json
Streams       : {[Microsoft.WindowsTerminal, System.Collections.Hashtable], [Microsoft.WindowsTerminalPreview, System.Collections.Hashtable]}
```

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
