### PR TITLE
fixes #206 - zabbix agent needs to stop the service if it detects it present

### DIFF
--- a/automatic/zabbix-agent/tools/chocolateyInstall.ps1
+++ b/automatic/zabbix-agent/tools/chocolateyInstall.ps1
@@ -24,7 +24,7 @@ $PackageArgs = @{
 }
 
 try {
-  Get-ChocolateyUnzip @PackageArgs
+  Install-ChocolateyInstallPackage @PackageArgs
 
   if (!(Test-Path $configDir)) {
     New-Item $configDir -type directory

--- a/automatic/zabbix-agent/tools/chocolateyInstall.ps1
+++ b/automatic/zabbix-agent/tools/chocolateyInstall.ps1
@@ -24,7 +24,12 @@ $PackageArgs = @{
 }
 
 try {
-  Install-ChocolateyInstallPackage @PackageArgs
+
+  if ($service) {
+    $service.StopService()
+  }
+  
+  Get-ChocolateyUnzip @PackageArgs
 
   if (!(Test-Path $configDir)) {
     New-Item $configDir -type directory


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->
Revert Zabbix Agent install to use the .install package and msi rather than extract zip which fails because of things like managing services - Fixes #206 
## Description
<!-- Describe your changes in detail -->

reverts https://github.com/mkevenaar/chocolatey-packages/commit/175d1d81772859d1a2836c97a980cac1761f30dc to restore the previously working upgrade functionality for zabbix agent versions

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

fixes zabbix agent upgrades that are failing because extracting zip cannot succeed without doing things like stopping the service first

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
