### PR TITLE
(mysql.workbench) Fix automatic MySQL Workbench update in `update.ps1`

### DIFF
--- a/automatic/mysql.workbench/update.ps1
+++ b/automatic/mysql.workbench/update.ps1
@@ -1,6 +1,7 @@
 import-module au
 
-$releases = 'http://dev.mysql.com/downloads/tools/workbench/'
+$releases = 'https://github.com/mysql/mysql-workbench/tags'
+$mainlineVersionPrefix = '8.0.'
 
 function global:au_SearchReplace {
     @{
@@ -14,9 +15,9 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases
-    
-    $version = ($download_page.ParsedHtml.getElementsByTagName('h1') | ? innerhtml -match "^MySQL Workbench").innerhtml -replace "^MySQL Workbench "
-    $version = $version.Trim()
+
+    $versiondata = $download_page.Links.Href | Where-Object { $_ -match '^/mysql/mysql-workbench/releases/tag/(\d+\.\d+\.\d+)$' -and $Matches[1].StartsWith($mainlineVersionPrefix) } | ForEach-Object { Get-Version $_ } | Sort-Object -Property Version -Descending | Select-Object -First 1
+    $version = $versiondata.toString()
 
     $url = 'https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-' + $version + '-winx64.msi'
     $Latest = @{ URL32 = $url; Version = $version }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
* Uses the GitHub tags page to get the latest release version number, instead of the download page of the MySQL site.
* Specifies the mainline version prefix, since there could be multiple maintained release lines by Oracle.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
It is currently not possible to get the latest version, because the MySQL website requires a JavaScript enabled browser.

Fixes #197

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
I ran the update script locally:

```
PS C:\Repositories\chocolatey-packages\automatic\mysql.workbench> .\update.ps1
mysql.workbench - checking updates using au version 2022.10.24

URL check
  https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-winx64.msi
nuspec version: 8.0.31
remote version: 8.0.34
New version is available
Automatic checksum started
Using system proxy server ''.
Downloading chocolatey\mysql.workbench 32 bit
  from 'https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-winx64.msi'
Using system proxy server ''.

Download of mysql-workbench-community-8.0.34-winx64.msi (46,37 MB) completed.
Package downloaded and hash calculated for 32 bit version
Setting package description from README.md
Updating files
  $Latest data:
    Checksum32                (String)     231e6ad0d1e99707a90fc6e0f52a57242227dd28a8cb043a8ffbf0299fa1ef55
    ChecksumType32            (String)     sha256
    FileType                  (String)     msi
    NuspecVersion             (String)     8.0.31
    PackageName               (String)     mysql.workbench
    URL32                     (String)     https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-winx64.msi
    Version                   (String)     8.0.34
  mysql.workbench.nuspec
    setting id: mysql.workbench
    updating version: 8.0.31 -> 8.0.34
  tools\chocolateyInstall.ps1
    (^[$]checksumType\s*=\s*)('.*')     = $1'sha256'
    (^[$]url\s*=\s*)('.*')              = $1'https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-winx64.msi'
    (^[$]checksum\s*=\s*)('.*')         = $1'231e6ad0d1e99707a90fc6e0f52a57242227dd28a8cb043a8ffbf0299fa1ef55'
Running au_AfterUpdate
Downloading to mysql-workbench-community-8.0.34-winx64.msi - https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-winx64.msi
vt.exe: C:\Repositories\chocolatey-packages\automatic\mysql\update.ps1:42:9
Line |
  42 |          vt.exe scan file $file --apikey $env:VT_APIKEY
     |          ~~~~~~
     | The term 'vt.exe' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try 
     | again.

Package updated

Path          : C:\Repositories\chocolatey-packages\automatic\mysql.workbench
Name          : mysql.workbench
Updated       : True
Pushed        : False
RemoteVersion : 8.0.34
NuspecVersion : 8.0.31
Result        : {mysql.workbench - checking updates using au version 2022.10.24, , URL check,   https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-8.0.34-winx64.msi…}
Error         :
NuspecPath    : C:\Repositories\chocolatey-packages\automatic\mysql.workbench\mysql.workbench.nuspec
NuspecXml     : #document
Ignored       : False
IgnoreMessage :
StreamsPath   : C:\Repositories\chocolatey-packages\automatic\mysql.workbench\mysql.workbench.json
Streams       :
```

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
