### PR TITLE
(mysql.workbench) Fix URL used to check for new MySQL Workbench version in auto update script

### DIFF
--- a/automatic/mysql.workbench/update.ps1
+++ b/automatic/mysql.workbench/update.ps1
@@ -1,6 +1,6 @@
 import-module au
 
-$releases = 'http://dev.mysql.com/downloads/tools/workbench/'
+$releases = 'http://dev.mysql.com/downloads/workbench/'
 
 function global:au_SearchReplace {
     @{


### PR DESCRIPTION
## Description
The URL to download MySQL Workbench has moved from http://dev.mysql.com/downloads/tools/workbench/ to http://dev.mysql.com/downloads/workbench/, this PR just updates that URL to fix the auto update script so that the package will be updated properly again.

## Motivation and Context
Currently the auto update script for the package is broken causing the package to not get automatically updated properly. This PR updates the URL used the check for new versions of MySQL Workbench fixing the auto update script so that the package can be automatically updated properly again.

Also, this PR fixes this issue https://github.com/mkevenaar/chocolatey-packages/issues/197 and not only that it updates MySQL Workbench to the version after that as soon as the script is ran.

## How Has this Been Tested?
I tested this locally on my dev machine by making the change and manually running the auto update script and observing that it updated and created the nupkg properly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
