### PR TITLE
(crystaldiskinfo) fix AU script for install and portable

### DIFF
--- a/automatic/crystaldiskinfo.install/update.ps1
+++ b/automatic/crystaldiskinfo.install/update.ps1
@@ -1,19 +1,15 @@
 Import-Module Chocolatey-AU
 
 $releases = 'https://crystalmark.info/redirect.php?product=CrystalDiskInfoInstaller'
-$feed = 'https://osdn.net/projects/crystaldiskinfo/releases/rss'
+$downloads = 'https://sourceforge.net/projects/crystaldiskinfo/rss?path=/'
 
-function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
+function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge -FileNameSkip 1 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $feed -UseBasicParsing
-  $feed = ([xml]$download_page.Content).rss.channel
+  $download_page = Invoke-WebRequest -Uri $downloads -UseBasicParsing
 
   $re = "CrystalDiskInfo([_0-9]+(RC\d+)?)\.exe"
-
-  $url = ($feed.item[0].files.file | where-object "#text" -Match $re | Sort-Object url -Descending | Select-Object -First 1).url -Replace "https://osdn.net/projects/crystaldiskinfo/downloads/", "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskinfo/" -Replace "/$"
-
-  $url = Get-RedirectedUrl $url
+  $url = ([xml]$download_page.Content).rss.channel.item | Where-Object link -match $re | Select-Object -First 1 -ExpandProperty link
 
   $version = (([regex]::Match($url,$re)).Captures.Groups[1].value) -Replace "_", "."
   $version = Get-Version($version)

--- a/automatic/crystaldiskinfo.portable/update.ps1
+++ b/automatic/crystaldiskinfo.portable/update.ps1
@@ -1,21 +1,17 @@
 Import-Module Chocolatey-AU
 
 $releases = 'https://crystalmark.info/redirect.php?product=CrystalDiskInfoInstaller'
-$feed = 'https://osdn.net/projects/crystaldiskinfo/releases/rss'
+$downloads = 'https://sourceforge.net/projects/crystaldiskinfo/rss?path=/'
 
-function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge }
+function global:au_BeforeUpdate { Get-RemoteFiles -NoSuffix -Purge -FileNameSkip 1 }
 
 function global:au_GetLatest {
-  $download_page = Invoke-WebRequest -Uri $feed -UseBasicParsing
-  $feed = ([xml]$download_page.Content).rss.channel
-
+  $download_page = Invoke-WebRequest -Uri $downloads -UseBasicParsing
+    
   $re = "CrystalDiskInfo([_0-9]+(RC\d+)?)\.zip"
+  $url = ([xml]$download_page.Content).rss.channel.item | Where-Object link -match $re | Select-Object -First 1 -ExpandProperty link
 
-  $url = ($feed.item[0].files.file | where-object "#text" -Match $re | Sort-Object url -Descending | Select-Object -First 1).url -Replace "https://osdn.net/projects/crystaldiskinfo/downloads/", "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskinfo/" -Replace "/$"
-
-  $url = Get-RedirectedUrl $url
-
-  $version = (([regex]::Match($url,$re)).Captures.Groups[1].value) -Replace "_", "." -Replace "RC", "-RC"
+  $version = (([regex]::Match($url,$re)).Captures.Groups[1].value) -Replace "_", "."
   $version = Get-Version($version)
 
   return @{


### PR DESCRIPTION
## Description

Updates AU scripts for `crystaldiskinfo.install` and `crystaldiskinfo.portable` to use the current sourceforge download location. 

## Motivation and Context

Fixes #229

## How Has this Been Tested?

Tested AU scripts on Windows 10, tested package

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
