### PR TITLE
(slack) remove 32 bit installer as no longer offered

### DIFF
--- a/automatic/slack/tools/chocolateyInstall.ps1
+++ b/automatic/slack/tools/chocolateyInstall.ps1
@@ -1,9 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url32          = 'https://downloads.slack-edge.com/desktop-releases/windows/ia32/4.38.127/slack-standalone-4.38.127.0.msi'
-$checksum32     = '0bedbb08fbd508b63291fd39db91d370eabbc66cfb53e01a9aa9fbae6b11f0c5'
-$checksumType32 = 'sha256'
 $url64          = 'https://downloads.slack-edge.com/desktop-releases/windows/x64/4.38.127/slack-standalone-4.38.127.0.msi'
 $checksum64     = '2623eb314f049dfaa6f99d0158c5a4c05c81ca8203f350082b86549152b151cf'
 $checksumType64 = 'sha256'
@@ -12,9 +9,6 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'msi'
-  url           = $url32
-  checksum      = $checksum32
-  checksumType  = $checksumType32
   url64bit      = $url64
   checksum64    = $checksum64
   checksumType64= $checksumType64

--- a/automatic/slack/update.ps1
+++ b/automatic/slack/update.ps1
@@ -5,9 +5,6 @@ $releases = 'https://slack.com/intl/en-nl/downloads/windows'
 function global:au_SearchReplace {
     @{
         'tools\chocolateyInstall.ps1' = @{
-            "(^[$]url32\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
-            "(^[$]checksum32\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
-            "(^[$]checksumType32\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
             "(^[$]url64\s*=\s*)('.*')"      = "`$1'$($Latest.URL64)'"
             "(^[$]checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
             "(^[$]checksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
@@ -18,7 +15,6 @@ function global:au_SearchReplace {
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    $url32 = Get-RedirectedUrl 'https://slack.com/ssb/download-win-msi'
     $url64 = Get-RedirectedUrl 'https://slack.com/ssb/download-win64-msi'
 
     $re = "Version (.+\d)</span>"
@@ -26,10 +22,9 @@ function global:au_GetLatest {
     $version = ([regex]::Match($download_page.RawContent, $re)).Captures.Groups[1].value
 
     return @{
-        URL32 = $url32
         URL64 = $url64
         Version = $version
     }
 }
 
-update
+update -ChecksumFor 64


### PR DESCRIPTION
## Description

Removes the 32 bit installer from the install script and the update script. 

## Motivation and Context

32 bit build no longer available

## How Has this Been Tested?

Tested update script and package on a windows 10 machine

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
