### PR TITLE
Update PowerToys script to newer tag

### DIFF
--- a/automatic/powertoys/tools/chocolateyinstall.ps1
+++ b/automatic/powertoys/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 
 $toolsDir       = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $version        = "0.82.1"
-$url64 = 'https://github.com/microsoft/PowerToys/releases/download/V0.82.1/PowerToysSetup-0.82.1-x64.exe'
+$url64 = 'https://github.com/microsoft/PowerToys/releases/download/v0.82.1/PowerToysSetup-0.82.1-x64.exe'
 $checksum64 = 'b8fa7e7c8f88b69e070e234f561d32807634e2e9d782edbb9dc35f3a454f2264'
 
 $WindowsVersion=[Environment]::OSVersion.Version


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->

Updates the PowerToys install script for the new tag for 0.82.1: "v0.82.1" (notice lowercase "v")

## Motivation and Context

I'm a dev lead in PowerToys. Proof in : https://github.com/microsoft/PowerToys/blob/main/COMMUNITY.md#powertoys-core-team

![image](https://github.com/user-attachments/assets/667dcfee-eebd-4230-b37a-e887e6ddb2d8)

We wrongly released the 0.82.1 tag as "V0.82.1" instead of "v0.82.1". We've just corrected that. Downloads should now contain lowercase "v": https://github.com/microsoft/PowerToys/releases/tag/v0.82.1

This PR reflects that correction.

## How Has this Been Tested?

Links work with lowercase tag.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
