### PR TITLE
Increment zerotier-one package version to trigger publishing workflow

### DIFF
--- a/automatic/zerotier-one/update.ps1
+++ b/automatic/zerotier-one/update.ps1
@@ -12,6 +12,10 @@ function global:au_GetLatest {
     $version = '1.6.6'
   }
 
+  if ($version -eq '1.14.0.20240819') {
+    $version = '1.14.0'
+  }
+
   $version = Get-Version($version)
 
   $url32 = 'https://download.zerotier.com/RELEASES/' + $version + '/dist/ZeroTierOne.msi'

--- a/automatic/zerotier-one/zerotier-one.nuspec
+++ b/automatic/zerotier-one/zerotier-one.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>1.14.0</version>
+    <version>1.14.0.20240819</version>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Maurice Kevenaar</owners>
     <!-- ============================== -->


### PR DESCRIPTION
Despite the fix for the zerotier .msi filename having been committed several days ago, the changes are not reflected in the CCP repository. My brief overview of the relevant documentation indicated that the issue is likely the failure to increment the package version concurrent with the changes being committed. This PR corrects the oversight in accordance [documented best practices](https://docs.chocolatey.org/en-us/create/create-packages/#package-fix-version-notation).

## Description

Increment package version from '1.14.0' (upstream release version) to '1.14.0.20240819'. Simultaneously add override logic for version string parsing in update.ps1 in the style of existing override conditional.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
