### PR TITLE
Fixed dymo-label package no longer working.

### DIFF
--- a/automatic/dymo-label/tools/chocolateyInstall.ps1
+++ b/automatic/dymo-label/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop';
 
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url          = 'https://s3.amazonaws.com/download.dymo.com/dymo/Software/Win/DLS8Setup8.7.4.exe'
+$url          = 'https://download.dymo.com/dymo/Software/Win/DLS8Setup8.7.4.exe'
 $checksum     = '409d79f053ba0c803ce83b71e8245992cd63708fa27017f48a5063826f1bea4d'
 $checksumType = 'sha256'
 


### PR DESCRIPTION

Fixed dymo-label package no longer working.

## Description
Changed the CDN used to get the dymo label exe

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
