### PR TITLE
googledrive: add /NoDesktopIcon parameter

### DIFF
--- a/automatic/googledrive/README.md
+++ b/automatic/googledrive/README.md
@@ -7,6 +7,7 @@ Choose folders on your computer to sync with Google Drive or backup to Google Ph
 ## Package Parameters
 
 - `/NoStart` - Do not start Google Drive after installation.
+- `/NoDesktopIcon` - Do not create a Google Drive shortcut on desktop.
 - `/NoGsuiteIcons` - Do not create Google Suite shortcuts on desktop.
 
 **Please Note**: This is an automatically updated package. If you find it is

--- a/automatic/googledrive/googledrive.nuspec
+++ b/automatic/googledrive/googledrive.nuspec
@@ -51,6 +51,7 @@ Choose folders on your computer to sync with Google Drive or backup to Google Ph
 ## Package Parameters
 
 - `/NoStart` - Do not start Google Drive after installation.
+- `/NoDesktopIcon` - Do not create a Google Drive shortcut on desktop.
 - `/NoGsuiteIcons` - Do not create Google Suite shortcuts on desktop.
 
 **Please Note**: This is an automatically updated package. If you find it is

--- a/automatic/googledrive/tools/chocolateyInstall.ps1
+++ b/automatic/googledrive/tools/chocolateyInstall.ps1
@@ -27,13 +27,18 @@ else {
     checksum       = $checksum
     checksumType   = $checksumType
     softwareName   = 'Google Drive*'
-    silentArgs     = "--silent --desktop_shortcut"
+    silentArgs     = "--silent"
     validExitCodes = @(0, 1641, 3010)
   }
 
   $pp = Get-PackageParameters
   if ($pp.NoStart) {
     $packageArgs['silentArgs'] += ' --skip_launch_new'
+  }
+  if ($pp.NoDesktopIcon) {
+    $packageArgs['silentArgs'] += ' --desktop_shortcut=false'
+  } else {
+    $packageArgs['silentArgs'] += ' --desktop_shortcut'
   }
   if ($pp.NoGsuiteIcons) {
     $packageArgs['silentArgs'] += ' --gsuite_shortcuts=false'


### PR DESCRIPTION
(googledrive) add /NoDesktopIcon parameter

## Description
Add /NoDesktopIcon parameter to disable creation of a google drive desktop shortcut.

## Motivation and Context
Installing Google Drive without creating any desktop shortcuts.

## How Has this Been Tested?
Testing the flag itself
- Tested that running GoogleDriveSetup.exe with "--silent" does not create a desktop shortcut.
- Tested that running GoogleDriveSetup.exe with "--silent --desktop_shorcut=false" does not create a desktop shortcut.
- Tested that running GoogleDriveSetup.exe with "--silent --desktop_shorcut=true" creates a desktop shortcut.
- Tested that running GoogleDriveSetup.exe with "--silent --desktop_shorcut" creates a desktop shortcut.

Testing the package
Ran choco pack then installed the package:
- without any params, a Google Drive shortcut is created and the Gsuite shortcuts are created.
- with /NoDesktopIcon param, a Google Drive shortcut was not created but the Gsuite shortcuts are created.
- with /NoDesktopIcon and /NoGsuiteIcons params, no shortcuts are created.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package).
- [x] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
