### PR TITLE
Update chocolateyInstall.ps1 of microsoft-windows-terminal for Issue #228

### DIFF
--- a/automatic/microsoft-windows-terminal/tools/chocolateyInstall.ps1
+++ b/automatic/microsoft-windows-terminal/tools/chocolateyInstall.ps1
@@ -21,7 +21,7 @@ if ($PreRelease -match "True") {
   $AppxPackageName += "Preview"
 }
 
-[version]$AppxVer = (Get-AppxPackage -Name $AppxPackageName -AllUsers -PackageTypeFilter Bundle).Version
+[version]$AppxVer = (Get-AppxPackage -Name $AppxPackageName -AllUsers -PackageTypeFilter Bundle | Select-Object -Last 1).Version
 
 if ($AppxVer -gt [version]$version) {
   # you can't install an older version of an installed appx package, you'd need to remove it first
@@ -30,11 +30,11 @@ if ($AppxVer -gt [version]$version) {
     if($env:ChocolateyForce) {
       # you can't install the same version of an appx package, you need to remove it first
       Write-Host Removing already installed version first.
-      Remove-AppxPackage -AllUsers -Package (Get-AppxPackage -Name $AppxPackageName -AllUsers -PackageTypeFilter Bundle)
+      Remove-AppxPackage -AllUsers -Package (Get-AppxPackage -Name $AppxPackageName -AllUsers -PackageTypeFilter Bundle | Select-Object -Last 1)
     } else {
     Write-Host The $version version of Windows-Terminal is already installed. If you want to reinstall use --force
     return
   }
 }
 
-Add-ProvisionedAppPackage -Online -SkipLicense -PackagePath $fileName
+Add-ProvisionedAppXPackage -Online -SkipLicense -PackagePath $fileName


### PR DESCRIPTION
## Description
- Added `| Select-Object -Last 1` after `Get-AppxPackage` calls, because the calls might return an Array. (see [Get-AppxPackage Documentation](https://learn.microsoft.com/en-us/powershell/module/appx/get-appxpackage)) 
- Changed `Add-ProvisionedAppPackage` to `Add-ProvisionedAppxPackage` for more clarity.

## Motivation and Context
It fixes the Issue #228 that prevents installation or update of the microsoft-windows-terminal package.

## How Has this Been Tested?
I manually changed the original script on my environment (Win 10 x64) and excuted the following command line:
`& 'C:\ProgramData\chocolatey\helpers\chocolateyScriptRunner.ps1' -packageScript 'C:\ProgramData\chocolatey\lib-bad\microsoft-windows-terminal\1.21.2911\tools\chocolateyInstall.ps1' -installArguments '' -packageParameters '' -preRunHookScripts $null -postRunHookScripts $null`

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).

fixes #228