### PR TITLE
(samsung-magician) Fix Samsung Magician

### DIFF
--- a/automatic/samsung-magician/samsung-magician.nuspec
+++ b/automatic/samsung-magician/samsung-magician.nuspec
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Read this before creating packages: https://chocolatey.org/docs/create-packages -->
 <!-- It is especially important to read the above link to understand additional requirements when publishing packages to the community feed aka dot org (https://community.chocolatey.org/packages). -->
-
 <!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
-
 <!--
 This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Reference. Chocolatey uses a special version of NuGet.Core that allows us to do more than was initially possible. As such there are certain things to be aware of:
 
@@ -11,7 +9,6 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 * Any of the following elements can ONLY be used by choco tools - projectSourceUrl, docsUrl, mailingListUrl, bugTrackerUrl, packageSourceUrl, provides, conflicts, replaces
 * nuget.exe can still install packages with those elements but they are ignored. Any authoring tools or commands will error on those elements
 -->
-
 <!-- You can embed software files directly into packages, as long as you are not bound by distribution rights. -->
 <!-- * If you are an organization making private packages, you probably have no issues here -->
 <!-- * If you are releasing to the community feed, you need to consider distribution rights. -->
@@ -26,11 +23,10 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>8.0.0.900</version>
+    <version>8.2.0.880</version>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Maurice Kevenaar, virtualex</owners>
     <!-- ============================== -->
-
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <!-- This section is about the software itself -->
     <title>Samsung Magician</title>
@@ -40,8 +36,9 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <iconUrl>https://cdn.jsdelivr.net/gh/mkevenaar/chocolatey-packages@e1ad9513cb5d8d6c79ce23c9023f141ac1b8df2d/icons/samsung-magician.png</iconUrl>
     <!-- copyright is usually years and software vendor, but not required for internal feeds -->
     <copyright>Samsung Electronics</copyright>
-    <tags>samsung-magician samsung ssd admin</tags>
+    <tags>samsung-magician samsung ssd magician nvme firmware update test factory manufacturer</tags>
     <licenseUrl>https://www.samsung.com/us/common/legal.html</licenseUrl>
+    <releaseNotes>https://semiconductor.samsung.com/consumer-storage/support/tools/</releaseNotes>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <packageSourceUrl>https://github.com/mkevenaar/chocolatey-packages/tree/master/automatic/samsung-magician</packageSourceUrl>
     <docsUrl>https://www.samsung.com/semiconductor/minisite/ssd/product/consumer/magician/</docsUrl>
@@ -52,15 +49,13 @@ Reaching the maximum potential and proficiency of your Samsung SSD is easy. With
 **Please Note**: This is an automatically updated package. If you find it is
 out of date by more than a day or two, please contact the maintainer(s) and
 let them know [here](https://github.com/mkevenaar/chocolatey-packages/issues) that the package is no longer updating correctly.
-]]></description>
+]]>    </description>
     <!-- =============================== -->
-
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
     <dependencies>
-        <dependency id="autohotkey.portable" version="2.0.0" />
-        <dependency id="dotnet4.6.1" />
+      <dependency id="autohotkey.portable" version="2.0.0" />
+      <dependency id="dotnetfx" />
     </dependencies>
-
     <!--<provides>NOT YET IMPLEMENTED</provides>-->
     <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
     <!--<replaces>NOT YET IMPLEMENTED</replaces>-->

--- a/automatic/samsung-magician/tools/chocolateyInstall.ahk
+++ b/automatic/samsung-magician/tools/chocolateyInstall.ahk
@@ -1,56 +1,80 @@
 #Requires AutoHotkey v2.0
-#Warn  ; Enable warnings to assist with detecting common errors.
-#NoTrayIcon
-SetTitleMatchMode 1
-SetControlDelay -1
+#Warn
+#SingleInstance Force
+SetTitleMatchMode(1)
+SetControlDelay(-1)
 
-winTitleInstall := "Setup - Samsung Magician"
+winTitleDialog := "Setup" ; Common title for dialog windows
+dialogClass := "ahk_class #32770"
 
-WinWait("Select Setup Language",, 300)
-
+; Step 1: Language selection
+WinWait("Select Setup Language", , 30000)
 if WinExist("Select Setup Language")
+{
   WinActivate
-
-; Language selection
-WinWait("ahk_class TSelectLanguageForm")
-ControlClick "OK", "Select Setup Language",,,, "NA"
-
-; Wait for the overwrite confirmation dialog (for upgrades/forced reinstalls)
-SetTitleMatchMode("Regex")
-WinWait("ahk_class i)#32770|TWizardForm ahk_exe Samsung_Magician_installer.tmp")
-if WinExist("ahk_class #32770 ahk_exe Samsung_Magician_installer.tmp") {
-  ; Overwrite confirmation dialog
-  ControlClick "&Yes", "ahk_class #32770 ahk_exe Samsung_Magician_installer.tmp",,,, "NA"
+  ControlClick("OK", "Select Setup Language")
 }
 
-; Welcome screen
-WinWait("ahk_class TWizardForm ahk_exe Samsung_Magician_installer.tmp")
-SetTitleMatchMode 1
-ControlClick "&Next", winTitleInstall,,,, "NA"
+; Step 2 and Step 3: Handle dialogs dynamically
+WinWait(winTitleDialog " " dialogClass, , 30000) ; Wait for the "Setup" dialog with the specified class
 
-; License terms
-sleep 1000
-ControlClick "I &accept the agreement", winTitleInstall,,,, "NA"
-sleep 1000
-ControlClick "&Next", winTitleInstall,,,, "NA"
+; Retrieve the full visible text of the dialog
+dialogContent := WinGetText(winTitleDialog " " dialogClass)
 
-; Collection and Use of Personal Information
-sleep 1000
-ControlClick "I &accept the agreement", winTitleInstall,,,, "NA"
-sleep 1000
-ControlClick "&Next", winTitleInstall,,,, "NA"
+; Debugging: Uncomment this to view the retrieved text
+; MsgBox("Dialog Content: " dialogContent)
 
-; Additional tasks
-sleep 1000
-ControlClick "&Next", winTitleInstall,,,, "NA"
+; Determine if it's the "Already Installed" or GDPR dialog
+if InStr(dialogContent, "Samsung Magician is already installed")
+{
+  ; Handle "Already Installed" dialog
+  WinActivate
+  ControlClick("&Yes", winTitleDialog " " dialogClass) ; Click "Yes"
 
-; Ready to install
-sleep 1000
-ControlClick "&Install", winTitleInstall,,,, "NA"
+  ; Handle GDPR prompt
+  WinWait(winTitleDialog " " dialogClass, "Are you a resident of a European country (GDPR country) or Brazil?", , 30000)
+  WinActivate
+  ControlClick("&No", winTitleDialog " " dialogClass) ; Click "No"
 
-; Wait until the install process is finished
-WinWait(winTitleInstall, "Completing")
+}
+else if InStr(dialogContent, "Are you a resident of a European country (GDPR country) or Brazil?")
+{
+  ; Handle GDPR prompt
+  WinActivate
+  ControlClick("&No", winTitleDialog " " dialogClass) ; Click "No"
+}
 
-; Finish
-sleep 1000
-ControlClick "&Finish", winTitleInstall,,,, "NA"
+; Step 4: Welcome screen
+WinWait("Setup - Samsung Magician", "Welcome to the Samsung Magician Setup Wizard", , 30000)
+WinActivate
+ControlClick("&Next", "Setup - Samsung Magician")
+
+; Step 5: License agreement
+WinWait("Setup - Samsung Magician", "License Agreement", , 30000)
+ControlClick("I &accept the agreement", "Setup - Samsung Magician")
+ControlClick("&Next", "Setup - Samsung Magician")
+
+; Step 6: Collection and Use of Personal Information
+WinWait("Setup - Samsung Magician", "Collection and Use of Personal Information", , 15000)
+ControlClick("I &accept the agreement", "Setup - Samsung Magician")
+ControlClick("&Next", "Setup - Samsung Magician")
+
+; Step 7: Additional tasks
+WinWait("Setup - Samsung Magician", "Select Additional Tasks", , 15000)
+ControlClick("&Next", "Setup - Samsung Magician")
+
+; Step 8: Ready to install
+WinWait("Setup - Samsung Magician", "Ready to Install", , 15000)
+ControlClick("&Install", "Setup - Samsung Magician")
+
+; Step 9: Completing installation
+WinWait("Setup - Samsung Magician", "Completing the Samsung Magician Setup Wizard", , 15000)
+ControlClick("&Finish", "Setup - Samsung Magician")
+
+; Step 10: Close main window)
+; Wait for the loading window to appear & disappear
+WinWait("Samsung Magician ahk_exe SamsungMagician.exe ahk_class Chrome_WidgetWin_1", , 180000)
+Sleep(10000)
+; Wait for the actual window to appear
+WinWait("Samsung Magician ahk_exe SamsungMagician.exe ahk_class Chrome_WidgetWin_1", , 30000)
+WinClose

--- a/automatic/samsung-magician/tools/chocolateyInstall.ps1
+++ b/automatic/samsung-magician/tools/chocolateyInstall.ps1
@@ -3,43 +3,36 @@
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 . $toolsDir\helpers.ps1
 
-$url                       = 'https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_installer_Official_8.0.0.900_Windows.zip'
-$checksum                  = 'c786d822e1442d30bf63480a3c3a31c779e087753a060f4359f9f1351d44f311'
-$checksumType              = 'sha256'
-[version] $softwareVersion = '8.0.0.900'
+$url = 'https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_Installer_Official_8.2.0.880.exe'
+$checksum = 'c327ec05524d1447973050513e34942c7f4073141313d393f0a73025c4ebba26'
+$checksumType = 'sha256'
 
-$installedVersion = Get-InstalledVersion
-if ($installedVersion -gt $softwareVersion) {
-  Write-Output "Current installed version (v$installedVersion) must be uninstalled first..."
-  Uninstall-CurrentVersion
-}
-
+# Download the installer using Chocolatey's internal handling
 $packageArgs = @{
-  PackageName    = $env:ChocolateyPackageName
-  url            = $url
-  checksum       = $checksum
-  checksumType   = $checksumType
-  Destination    = $toolsDir
+  PackageName  = $env:ChocolateyPackageName
+  url          = $url
+  checksum     = $checksum
+  checksumType = $checksumType
+  Destination  = $toolsDir
 }
 
-Install-ChocolateyZipPackage @packageArgs
-
-$packageArgs = @{
-  packageName    = $env:ChocolateyPackageName
-  fileType       = 'exe'
-  file           = Get-Item $toolsDir\*.exe
-  softwareName   = 'Samsung Magician*'
-  silentArgs     = ""
-  validExitCodes = @(0,3010)
+# Use AutoHotkey portable from the Choco directory
+$ahkEXE = Get-ChildItem -Path "$env:ChocolateyInstall\lib\autohotkey.portable\tools" -Filter 'AutoHotKey.exe' -Recurse -ErrorAction SilentlyContinue
+if (-not $ahkEXE) {
+  Write-Error "AutoHotKey executable not found in $env:ChocolateyInstall\lib\autohotkey.portable\tools"
+  return
 }
 
-# silent install requires AutoHotKey
+# Start AutoHotKey script for the silent install
 $ahkFile = Join-Path $toolsDir 'chocolateyInstall.ahk'
-$ahkEXE = Get-ChildItem "$env:ChocolateyInstall\lib\autohotkey.portable" -Recurse -filter autohotkey.exe
 $ahkProc = Start-Process -FilePath $ahkEXE.FullName -ArgumentList $ahkFile -PassThru
 Write-Debug "AutoHotKey start time:`t$($ahkProc.StartTime.ToShortTimeString())"
 Write-Debug "Process ID:`t$($ahkProc.Id)"
 
-Install-ChocolateyInstallPackage @packageArgs
+Write-Output (("-") * 80)
+Write-Warning "Please wait a few minutes for Samsung Magician to install."
+Write-Warning "If you run into errors, please run the install again and refrain from using the computer during the install."
+Write-Output (("-") * 80)
 
-if (Get-Process -id $ahkProc.Id -ErrorAction SilentlyContinue) {Stop-Process -id $ahkProc.Id}
+# Install the package
+Install-ChocolateyPackage @packageArgs

--- a/automatic/samsung-magician/tools/chocolateyuninstall.ps1
+++ b/automatic/samsung-magician/tools/chocolateyuninstall.ps1
@@ -1,4 +1,5 @@
 ﻿$ErrorActionPreference = 'Stop'
+
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 . $toolsDir\helpers.ps1
 

--- a/automatic/samsung-magician/tools/helpers.ps1
+++ b/automatic/samsung-magician/tools/helpers.ps1
@@ -1,10 +1,12 @@
-﻿$softwareNamePattern = 'Samsung Magician*'
+﻿$ErrorActionPreference = 'Stop'
+
+$softwareNamePattern = 'Samsung Magician*'
 
 function Get-InstalledVersion {
   [array] $keys = Get-UninstallRegistryKey -SoftwareName $softwareNamePattern
 
   if ($keys.Length -ge 1) {
-      return [version] ($keys[0].DisplayVersion)
+    return [version] ($keys[0].DisplayVersion)
   }
 
   return $null
@@ -12,11 +14,11 @@ function Get-InstalledVersion {
 
 function Uninstall-CurrentVersion {
   $packageArgs = @{
-    packageName   = $env:ChocolateyPackageName
-    softwareName  = $softwareNamePattern
-    fileType      = 'exe'
-    silentArgs    = '/SILENT'
-    validExitCodes= @(0, 3010, 1605, 1614, 1641)
+    packageName    = $env:ChocolateyPackageName
+    softwareName   = $softwareNamePattern
+    fileType       = 'exe'
+    silentArgs     = '/SILENT'
+    validExitCodes = @(0, 3010, 1605, 1614, 1641)
   }
 
   [array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
@@ -38,7 +40,6 @@ function Uninstall-CurrentVersion {
     Write-Warning "$($key.Count) matches found!"
     Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
     Write-Warning "Please alert package maintainer the following keys were matched:"
-    $key | ForEach-Object {Write-Warning "- $($_.DisplayName)"}
+    $key | ForEach-Object { Write-Warning "- $($_.DisplayName)" }
   }
 }
-

--- a/automatic/samsung-magician/update.ps1
+++ b/automatic/samsung-magician/update.ps1
@@ -1,32 +1,37 @@
 ﻿Import-Module Chocolatey-AU
 
-$releases = 'https://www.samsung.com/semiconductor/minisite/ssd/download/tools/'
+$releases = 'https://semiconductor.samsung.com/consumer-storage/support/tools/'
 
 function global:au_SearchReplace {
     @{
         'tools\chocolateyInstall.ps1' = @{
-            "(^[$]url\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
-            "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
-            "(^[$]checksumType\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
+            "(^[$]url\s*=\s*)('.*')"                         = "`$1'$($Latest.URL32)'"
+            "(^[$]checksum\s*=\s*)('.*')"                    = "`$1'$($Latest.Checksum32)'"
+            "(^[$]checksumType\s*=\s*)('.*')"                = "`$1'$($Latest.ChecksumType32)'"
             "(^\[version\] [$]softwareVersion\s*=\s*)('.*')" = "`$1'$($Latest.RemoteVersion)'"
         }
-     }
+    }
 }
 
 function global:au_GetLatest {
     $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
 
-    $re  = "Samsung_Magician_[iI]nstaller_Official_(.+).zip"
+    # Updated regex to match the URL
+    $re = "Samsung_Magician_Installer_Official_(\d+\.\d+\.\d+\.\d+)\.exe"
+    $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -ExpandProperty href
 
-    $url = $download_page.links | Where-Object href -match $re | Select-Object -First 1 -expand href
+    if (-not $url) {
+        throw "Failed to find a download URL matching the expected pattern: $re"
+    }
 
-    $version = (([regex]::Match($url,$re)).Captures.Groups[1].value)
-    $version = (Get-Version $version).ToString()
+    # Extract version from the URL
+    $version = ([regex]::Match($url, $re)).Groups[1].Value
 
+    # Return the necessary details
     return @{
         RemoteVersion = $version
-        URL32 = $url
-        Version = $version
+        URL32         = $url
+        Version       = $version
     }
 }
 


### PR DESCRIPTION
## Description
Related to #271.

I removed the uninstall command from `chocolateyInstall.ps1` because it doesn't matter if you uninstall it or not, Samsung Magician leaves some registry key that the installer then asks if you want to reinstall.

## Motivation and Context

There were a few reasons the existing package broke:

- Samsung changed from EXE to ZIP
- The setup prompts changed
- Unfortunately although their packager supports silent installs with `/silent`, Samsung has actually blocked silent installs (message box upon attempting)

The part we'll have to figure out is because there is a GDPR prompt, whether to answer Yes or No to this setup question:

![image](https://github.com/user-attachments/assets/97b2f8b6-da7f-481b-b7a5-1b68befa3577)

Since Chocolatey doesn't determine GDPR itself, according to Perplexity.ai, this could GDPR issue could be complex..

![image](https://github.com/user-attachments/assets/c5db2df9-7a7b-45a0-96ea-440551a009c5)

Right now I just have it clicking "No". We could create a Choco parameter so if the user is in the GDPR, they would have to add `/gdpr` as a param to the `choco install` command. Thoughts?

## How Has this Been Tested?
Tested on a machine with Samsung Magician already installed, and tested on a Windows 11 VM without anything installed.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).
