### PR TITLE
PowerToys: Drop unused .NET runtime dependency

### DIFF
--- a/automatic/powertoys/powertoys.nuspec
+++ b/automatic/powertoys/powertoys.nuspec
@@ -62,7 +62,6 @@ let them know [here](https://github.com/mkevenaar/chocolatey-packages/issues) th
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
     <dependencies>
-      <dependency id="dotnet-desktopruntime" />
       <dependency id="vcredist140" />
     </dependencies>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
<!-- Describe your changes in detail -->
PowerToys is packaged with its own copy of the .NET desktop runtime, and does not require a system installation as well.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->
Fixes #285.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->
Installed, uninstalled and reinstalled locally.  PowerToys UI and a handful of tested toys (Awake, Advanced Paste, Find My Mouse) appear to be working as expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~~New feature (non-breaking change which adds functionality)~~
- ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- ~~Migrated package (a package has been migrated from another repository)~~

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- ~~My change requires a change to documentation (this usually means the notes in the description of a package).~~
- ~~I have updated the documentation accordingly (this usually means the notes in the description of a package).~~
- ~~I have updated the package description and it is less than 4000 characters.~~
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [x] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
